### PR TITLE
test(server): Add simple start, request, stop server test in bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
 - 'if [[ "$COVERAGE" != "1" ]]; then composer test; fi'
 - 'if [[ "$COVERAGE" == "1" ]]; then composer analyse; fi'
 - 'if [[ "$COVERAGE" == "1" ]]; then composer code-coverage; fi'
+- 'for f in ./tests/Server/*.sh; do echo "[Test] $f"; bash "$f" -H || return 1; done;'
 
 before_deploy:
 - >-

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34d8ca1be2f7590332e27a4323d2d927",
+    "content-hash": "5e37b1d7188031ec0132fd980e50a1e0",
     "packages": [
         {
             "name": "beberlei/assert",

--- a/tests/Fixtures/Symfony/TestAppKernel.php
+++ b/tests/Fixtures/Symfony/TestAppKernel.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+namespace K911\Swoole\Tests\Fixtures\Symfony;
+
+use Exception;
+use Generator;
 use K911\Swoole\Bridge\Symfony\Bundle\SwooleBundle;
 use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\TestBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -54,7 +58,7 @@ class TestAppKernel extends Kernel
      */
     protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
-        $routes->import('routing.yml');
+        $routes->import('app/routing.yml');
     }
 
     /**
@@ -64,9 +68,7 @@ class TestAppKernel extends Kernel
      */
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
-        $c->setParameter('kernel.project_dir', __DIR__);
-
-        $confDir = __DIR__.'/config';
+        $confDir = $this->getProjectDir().'/config';
         $loader->load($confDir.'/*'.self::CONFIG_EXTENSIONS, 'glob');
         if (\is_dir($confDir.'/'.$this->environment)) {
             $loader->load($confDir.'/'.$this->environment.'/**/*'.self::CONFIG_EXTENSIONS, 'glob');
@@ -75,6 +77,14 @@ class TestAppKernel extends Kernel
 
     private function getVarDir(): string
     {
-        return __DIR__.'/var';
+        return $this->getProjectDir().'/var';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProjectDir(): string
+    {
+        return __DIR__.'/app';
     }
 }

--- a/tests/Fixtures/Symfony/app/console
+++ b/tests/Fixtures/Symfony/app/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use K911\Swoole\Tests\Fixtures\Symfony\TestAppKernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
@@ -8,7 +9,6 @@ use Symfony\Component\Debug\Debug;
 \set_time_limit(0);
 
 require __DIR__.'/../../../../vendor/autoload.php';
-require __DIR__.'/TestAppKernel.php';
 
 if (!\class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');

--- a/tests/Server/001-swoole-server-start-response-stop.sh
+++ b/tests/Server/001-swoole-server-start-response-stop.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cd "$( dirname "${BASH_SOURCE[0]}" )/../Fixtures/Symfony/app";
+
+HOST=localhost
+PORT=9999
+CURL_REQUEST=http://${HOST}:${PORT}
+EXIT_CODE=0
+
+./console swoole:server:start --port ${PORT} --ansi
+
+echo "[Info] Executing curl request: $CURL_REQUEST";
+RESULT=$(curl "http://$HOST:$PORT" -s)
+echo "[Info] Result: $RESULT";
+if [[ "$RESULT" = '{"hello":"world!"}' ]]; then
+    echo "[Test] OK";
+else
+    echo "[Test] FAIL";
+    EXIT_CODE=1;
+fi
+
+./console swoole:server:stop --ansi
+
+exit ${EXIT_CODE};


### PR DESCRIPTION
It's easier to test server commands as a bash script, since swoole
creates multiple processes.