### PR TITLE
refactor(di): Simplify registering configurators

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/ServerReloadCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerReloadCommand.php
@@ -23,8 +23,8 @@ final class ServerReloadCommand extends Command
     public function __construct(
         HttpServer $server,
         HttpServerConfiguration $serverConfiguration,
-        ParameterBagInterface $parameterBag)
-    {
+        ParameterBagInterface $parameterBag
+    ) {
         $this->server = $server;
         $this->serverConfiguration = $serverConfiguration;
         $this->parameterBag = $parameterBag;

--- a/src/Bridge/Symfony/Bundle/Command/ServerStopCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStopCommand.php
@@ -23,8 +23,8 @@ final class ServerStopCommand extends Command
     public function __construct(
         HttpServer $server,
         HttpServerConfiguration $serverConfiguration,
-        ParameterBagInterface $parameterBag)
-    {
+        ParameterBagInterface $parameterBag
+    ) {
         $this->server = $server;
         $this->serverConfiguration = $serverConfiguration;
         $this->parameterBag = $parameterBag;

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -49,10 +49,10 @@ final class SwooleExtension extends Extension implements PrependExtensionInterfa
         $configuration = Configuration::fromTreeBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
+        $loader->load('commands.yaml');
 
         $container->registerForAutoconfiguration(BootableInterface::class)
             ->addTag('swoole_bundle.bootable_service');
-
         $container->registerForAutoconfiguration(ConfiguratorInterface::class)
             ->addTag('swoole_bundle.server_configurator');
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/commands.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/commands.yaml
@@ -1,0 +1,49 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStopCommand':
+        tags: ['console.command']
+
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerReloadCommand':
+        tags: ['console.command']
+
+    'swoole_bundle.server.http_server.configurator.for_server_start_command':
+        class: K911\Swoole\Server\Configurator\ChainConfigurator
+        arguments:
+        - '@swoole_bundle.server.http_server.configurator'
+        - '@swoole_bundle.server.http_server.configurator.with_request_handler'
+        autoconfigure: false
+
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStartCommand':
+        tags: ['console.command']
+        arguments:
+            $serverConfigurator: '@swoole_bundle.server.http_server.configurator.for_server_start_command'
+
+    'swoole_bundle.server.http_server.configurator.for_server_run_command':
+        class: K911\Swoole\Server\Configurator\ChainConfigurator
+        arguments:
+        - '@swoole_bundle.server.http_server.configurator'
+        - '@swoole_bundle.server.http_server.configurator.with_request_handler'
+        - '@swoole_bundle.server.http_server.configurator.with_sigint_handler'
+        autoconfigure: false
+
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerRunCommand':
+        tags: ['console.command']
+        arguments:
+            $serverConfigurator: '@swoole_bundle.server.http_server.configurator.for_server_run_command'
+
+    'swoole_bundle.server.http_server.configurator.for_server_profile_command':
+        class: K911\Swoole\Server\Configurator\ChainConfigurator
+        arguments:
+        - '@swoole_bundle.server.http_server.configurator'
+        - '@swoole_bundle.server.http_server.configurator.with_limited_request_handler'
+        - '@swoole_bundle.server.http_server.configurator.with_sigint_handler'
+        autoconfigure: false
+
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerProfileCommand':
+        tags: ['console.command']
+        arguments:
+            $serverConfigurator: '@swoole_bundle.server.http_server.configurator.for_server_profile_command'

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
@@ -33,9 +33,16 @@ services:
 
     'K911\Swoole\Server\Configurator\WithHttpServerConfiguration':
 
-    'K911\Swoole\Server\Configurator\ConfiguratorInterface':
+    'swoole_bundle.server.http_server.configurator':
         class: K911\Swoole\Server\Configurator\ChainConfigurator
         arguments: [!tagged 'swoole_bundle.server_configurator']
+        autoconfigure: false
+
+    'K911\Swoole\Server\Configurator\ConfiguratorInterface':
+        alias: 'swoole_bundle.server.http_server.configurator'
+
+    'swoole_bundle.server.http_server.configurator.with_request_handler':
+        class: K911\Swoole\Server\Configurator\WithRequestHandler
         autoconfigure: false
 
     'swoole_bundle.server.http_server.configurator.with_limited_request_handler':
@@ -44,57 +51,9 @@ services:
         arguments:
             $requestHandler: '@K911\Swoole\Server\RequestHandler\LimitedRequestHandler'
 
-    'swoole_bundle.server.http_server.configurator.with_request_handler':
-        class: K911\Swoole\Server\Configurator\WithRequestHandler
-        autoconfigure: false
-
-    'swoole_bundle.server.http_server.configurator.with_sigint_and_request_handler':
+    'swoole_bundle.server.http_server.configurator.with_sigint_handler':
         class: K911\Swoole\Server\Configurator\WithServerStartHandler
         autoconfigure: false
         arguments:
-            $decorated: '@swoole_bundle.server.http_server.configurator.with_request_handler'
             $handler: '@K911\Swoole\Server\LifecycleHandler\SigIntHandler'
 
-    'swoole_bundle.server.http_server.configurator.with_sigint_and_limited_request_handler':
-        class: K911\Swoole\Server\Configurator\WithServerStartHandler
-        autoconfigure: false
-        arguments:
-            $decorated: '@swoole_bundle.server.http_server.configurator.with_limited_request_handler'
-            $handler: '@K911\Swoole\Server\LifecycleHandler\SigIntHandler'
-
-    'swoole_bundle.server.http_server.factory':
-        class: K911\Swoole\Server\HttpServerFactory
-        arguments:
-            $configurator: '@swoole_bundle.server.http_server.configurator.with_request_handler'
-
-    'swoole_bundle.server.http_server.sigint_factory':
-        class: K911\Swoole\Server\HttpServerFactory
-        arguments:
-            $configurator: '@swoole_bundle.server.http_server.configurator.with_sigint_and_request_handler'
-
-    'swoole_bundle.server.http_server.sigint_and_limited_factory':
-        class: K911\Swoole\Server\HttpServerFactory
-        arguments:
-            $configurator: '@swoole_bundle.server.http_server.configurator.with_sigint_and_limited_request_handler'
-
-
-    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStartCommand':
-        tags: ['console.command']
-        arguments:
-            $serverFactory: '@swoole_bundle.server.http_server.factory'
-
-    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStopCommand':
-        tags: ['console.command']
-
-    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerReloadCommand':
-        tags: ['console.command']
-
-    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerRunCommand':
-        tags: ['console.command']
-        arguments:
-            $serverFactory: '@swoole_bundle.server.http_server.sigint_factory'
-
-    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerProfileCommand':
-        tags: ['console.command']
-        arguments:
-            $serverFactory: '@swoole_bundle.server.http_server.sigint_and_limited_factory'

--- a/src/Server/Configurator/ChainConfigurator.php
+++ b/src/Server/Configurator/ChainConfigurator.php
@@ -4,21 +4,31 @@ declare(strict_types=1);
 
 namespace K911\Swoole\Server\Configurator;
 
+use Assert\Assertion;
+use Generator;
+use IteratorAggregate;
 use Swoole\Http\Server;
 
-final class ChainConfigurator implements ConfiguratorInterface
+final class ChainConfigurator implements ConfiguratorInterface, IteratorAggregate
 {
     /**
      * @var iterable<ConfiguratorInterface>
      */
+    private $collection;
+
+    /**
+     * @var ConfiguratorInterface[]
+     */
     private $configurators;
 
     /**
-     * @param iterable<ConfiguratorInterface> $configurators
+     * @param iterable<ConfiguratorInterface> $configuratorCollection
+     * @param ConfiguratorInterface           ...$configurators
      */
-    public function __construct(iterable $configurators)
+    public function __construct(iterable $configuratorCollection, ConfiguratorInterface ...$configurators)
     {
         $this->configurators = $configurators;
+        $this->collection = $configuratorCollection;
     }
 
     /**
@@ -27,8 +37,23 @@ final class ChainConfigurator implements ConfiguratorInterface
     public function configure(Server $server): void
     {
         /** @var ConfiguratorInterface $configurator */
-        foreach ($this->configurators as $configurator) {
+        foreach ($this->getIterator() as $configurator) {
             $configurator->configure($server);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): Generator
+    {
+        foreach ($this->collection as $item) {
+            Assertion::isInstanceOf($item, ConfiguratorInterface::class);
+            yield $item;
+        }
+
+        foreach ($this->configurators as $configurator) {
+            yield $configurator;
         }
     }
 }

--- a/src/Server/Configurator/WithRequestHandler.php
+++ b/src/Server/Configurator/WithRequestHandler.php
@@ -9,12 +9,10 @@ use Swoole\Http\Server;
 
 final class WithRequestHandler implements ConfiguratorInterface
 {
-    private $decorated;
     private $requestHandler;
 
-    public function __construct(ConfiguratorInterface $decorated, RequestHandlerInterface $requestHandler)
+    public function __construct(RequestHandlerInterface $requestHandler)
     {
-        $this->decorated = $decorated;
         $this->requestHandler = $requestHandler;
     }
 
@@ -23,8 +21,6 @@ final class WithRequestHandler implements ConfiguratorInterface
      */
     public function configure(Server $server): void
     {
-        $this->decorated->configure($server);
-
         $server->on('request', [$this->requestHandler, 'handle']);
     }
 }

--- a/src/Server/Configurator/WithServerStartHandler.php
+++ b/src/Server/Configurator/WithServerStartHandler.php
@@ -10,12 +10,10 @@ use Swoole\Http\Server;
 final class WithServerStartHandler implements ConfiguratorInterface
 {
     private $handler;
-    private $decorated;
 
-    public function __construct(ConfiguratorInterface $decorated, ServerStartHandlerInterface $handler)
+    public function __construct(ServerStartHandlerInterface $handler)
     {
         $this->handler = $handler;
-        $this->decorated = $decorated;
     }
 
     /**
@@ -23,8 +21,6 @@ final class WithServerStartHandler implements ConfiguratorInterface
      */
     public function configure(Server $server): void
     {
-        $this->decorated->configure($server);
-
         $server->on('start', [$this->handler, 'handle']);
     }
 }

--- a/src/Server/HttpServerFactory.php
+++ b/src/Server/HttpServerFactory.php
@@ -6,10 +6,9 @@ namespace K911\Swoole\Server;
 
 use Assert\Assertion;
 use K911\Swoole\Server\Config\Socket;
-use K911\Swoole\Server\Configurator\ConfiguratorInterface;
 use Swoole\Http\Server;
 
-class HttpServerFactory
+final class HttpServerFactory
 {
     private const SWOOLE_RUNNING_MODE = [
         'process' => SWOOLE_PROCESS,
@@ -17,28 +16,19 @@ class HttpServerFactory
 //        'thread' => SWOOLE_THREAD,
     ];
 
-    private $configurator;
-
-    public function __construct(ConfiguratorInterface $configurator)
-    {
-        $this->configurator = $configurator;
-    }
-
     /**
-     * @param Socket $socket
+     * @param Socket $socket      default socket
      * @param string $runningMode
      *
      * @return Server
      *
      * @see https://github.com/swoole/swoole-docs/blob/master/modules/swoole-server/methods/construct.md#parameter
      */
-    public function make(Socket $socket, string $runningMode = 'process'): Server
+    public static function make(Socket $socket, string $runningMode = 'process'): Server
     {
         Assertion::inArray($runningMode, \array_keys(self::SWOOLE_RUNNING_MODE));
 
         $server = new Server($socket->host(), $socket->port(), self::SWOOLE_RUNNING_MODE[$runningMode], $socket->type());
-
-        $this->configurator->configure($server);
 
         return $server;
     }

--- a/tests/Unit/Server/Configurator/ChainConfiguratorTest.php
+++ b/tests/Unit/Server/Configurator/ChainConfiguratorTest.php
@@ -15,13 +15,60 @@ class ChainConfiguratorTest extends TestCase
         $configuratorSpies = [new ConfiguratorSpy(), new ConfiguratorSpy(), new ConfiguratorSpy()];
         $serverDummy = new SwooleHttpServerDummy();
 
-        $chain = new ChainConfigurator($configuratorSpies);
+        $manager = new ChainConfigurator($configuratorSpies);
 
-        $chain->configure($serverDummy);
+        $manager->configure($serverDummy);
 
         /** @var ConfiguratorSpy $configuratorSpy */
         foreach ($configuratorSpies as $configuratorSpy) {
             $this->assertTrue($configuratorSpy->configured);
         }
+    }
+
+    public function testConfigureConfiguratorsUsingVariadic(): void
+    {
+        $configuratorSpies = [new ConfiguratorSpy(), new ConfiguratorSpy(), new ConfiguratorSpy()];
+        $serverDummy = new SwooleHttpServerDummy();
+
+        $manager = new ChainConfigurator([], ...$configuratorSpies);
+
+        $manager->configure($serverDummy);
+
+        /** @var ConfiguratorSpy $configuratorSpy */
+        foreach ($configuratorSpies as $configuratorSpy) {
+            $this->assertTrue($configuratorSpy->configured);
+        }
+    }
+
+    public function testConstructWithNotConfiguratorsWithoutConfigureShouldNotThrow(): void
+    {
+        new ChainConfigurator([$this->prophesize('object')]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @expectedException \Assert\InvalidArgumentException
+     * @expectedExceptionMessageRegExp  /Class "[a-zA-Z\\]+" was expected to be instanceof of "K911\\Swoole\\Server\\Configurator\\ConfiguratorInterface" but is not/
+     */
+    public function testConstructWithNotConfiguratorsWithConfigureShouldThrow(): void
+    {
+        $serverDummy = new SwooleHttpServerDummy();
+
+        $chain = new ChainConfigurator([$this->prophesize('object')]);
+
+        $chain->configure($serverDummy);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testIterator(): void
+    {
+        $configuratorDummiesOne = [new ConfiguratorDummy(), new ConfiguratorDummy(), new ConfiguratorDummy()];
+        $configuratorDummiesTwo = [new ConfiguratorDummy(), new ConfiguratorDummy()];
+
+        $chain = new ChainConfigurator($configuratorDummiesOne, ...$configuratorDummiesTwo);
+
+        $this->assertSame(\array_merge($configuratorDummiesOne, $configuratorDummiesTwo), \iterator_to_array($chain));
     }
 }

--- a/tests/Unit/Server/Configurator/WithRequestHandlerTest.php
+++ b/tests/Unit/Server/Configurator/WithRequestHandlerTest.php
@@ -17,11 +17,6 @@ class WithRequestHandlerTest extends TestCase
     private $requestHandlerDummy;
 
     /**
-     * @var ConfiguratorDummy
-     */
-    private $decoratedDummy;
-
-    /**
      * @var WithRequestHandler
      */
     private $configurator;
@@ -29,9 +24,8 @@ class WithRequestHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->requestHandlerDummy = new RequestHandlerDummy();
-        $this->decoratedDummy = new ConfiguratorDummy();
 
-        $this->configurator = new WithRequestHandler($this->decoratedDummy, $this->requestHandlerDummy);
+        $this->configurator = new WithRequestHandler($this->requestHandlerDummy);
     }
 
     public function testConfigure(): void


### PR DESCRIPTION
Creating matrix of configuration and http server factory services when some services needs to be
only in specific commands can become quite annoying

BREAKING CHANGE:

- Server\HttpServerFactory should not be instantiated anymore, due to
removed hard coupling with ConfiguratorInterface, and `make()` method
becomig static. Now use directly: `HttpServerFactory::make()`
- Configuring server (using object implementing ConfiguratorInterface)
now happens in execute method of AbstractServerStartCommand
- Server\Configurator\ChainConfigurator now accepts
ConfiguratorInterface variadic starting from second argument and
implements IteratorAggregate retruning its configurators to ease DI usage (see
src/Bridge/Symfony/Bundle/Resources/commands.yaml)