### PR TITLE
Remove process timeout

### DIFF
--- a/src/Common/XdebugHandler/XdebugHandler.php
+++ b/src/Common/XdebugHandler/XdebugHandler.php
@@ -72,6 +72,7 @@ final class XdebugHandler
 
         $process = new Process($command, null, $this->prepareEnvs());
         $process->setTty(Process::isTtySupported());
+        $process->setTimeout(null);
 
         return $process;
     }


### PR DESCRIPTION
By default symfony Process has timeout 60 seconds. So if a swoole server is automatically restarted to remove XDebug it is then terminated one minute later. That wasn't intended, right?