### PR TITLE
fix(di): Fix regression introduced in v0.4.3

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -189,7 +189,7 @@ final class SwooleExtension extends Extension implements PrependExtensionInterfa
                 ->setDecoratedService(RequestHandlerInterface::class, null, -10);
         }
 
-        if ($config['entity_manager_handler'] || (null === $config['entity_manager_handler'] && \class_exists(EntityManagerInterface::class) && $this->isBundleLoaded($container, 'doctrine'))) {
+        if ($config['entity_manager_handler'] || (null === $config['entity_manager_handler'] && \interface_exists(EntityManagerInterface::class) && $this->isBundleLoaded($container, 'doctrine'))) {
             $container->register(EntityManagerHandler::class)
                 ->addArgument(new Reference(EntityManagerHandler::class.'.inner'))
                 ->setAutowired(true)


### PR DESCRIPTION
Using \class_exists function for checking availabilty of interface is not possible,
\interface_exists used instead