### PR TITLE
feat(apiserver): Create API Server component

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -10,7 +10,7 @@ swoole:
     http_server:
         port: 9501
         host: localhost
-        running_mode: 'process'
+        running_mode: process
         socket_type: tcp
         ssl_enabled: false
         trusted_hosts: localhost,127.0.0.1
@@ -18,19 +18,67 @@ swoole:
             - '*'
             - 127.0.0.1/8
             - 192.168.2./16
-        static:
-            strategy: 'advanced'
-            public_dir: '%kernel.project_dir%/public'
-        hmr: 'auto'
+        
+        # enables static file serving
+        static: advanced
+        # equals to:
+        # ---
+        # static:
+        #     public_dir: '%kernel.project_dir%/public'
+        #     strategy: advanced
+        # ---
+        # strategy can be one of: (default) auto, off, advanced, default
+        #   - off: turn off feature
+        #   - auto: use 'advanced' when debug enabled or not production environment 
+        #   - advanced: use request handler class \K911\Swoole\Server\RequestHandler\AdvancedStaticFilesServer
+        #   - default: use default swoole static serving (faster than advanced, but supports less content types)
+        
+        # enables hot module reload using inotify
+        hmr: auto 
+        # hmr can be one of: off, (default) auto, inotify
+        #   - off: turn off feature
+        #   - auto: use inotify if installed in the system
+        #   - inotify: use inotify
+        
+        # enables api server on specific port
+        # by default it is disabled (can be also enabled using --api flag via cli)
+        api: true
+        # equals to:
+        # ---
+        # api: 
+        #     enabled: true
+        #     host: 0.0.0.0
+        #     port: 9200
+        
+        # additional swoole symfony bundle services
         services:
+            # see: \K911\Swoole\Bridge\Symfony\HttpKernel\DebugHttpKernelRequestHandler
             debug_handler: true
+            
+            # see: \K911\Swoole\Bridge\Symfony\HttpFoundation\TrustAllProxiesRequestHandler
             trust_all_proxies_handler: true
+            
+            # see: \K911\Swoole\Bridge\Symfony\HttpFoundation\CloudFrontRequestFactory
             cloudfront_proto_header_handler: true
+            
+            # see: \K911\Swoole\Bridge\Doctrine\ORM\EntityManagerHandler
             entity_manager_handler: true
+        
+        # swoole http server settings
+        # see https://www.swoole.co.uk/docs/modules/swoole-server/configuration
         settings:
-            worker_count: 4
             reactor_count: 2
-            log_file: '%kernel.logs_dir%/swoole_%kernel.environment%.log'
+            worker_count: 4
+            # when not set, swoole sets these are automatically set based on count of host CPU cores
+            
             log_level: auto
-            pid_file: '/var/run/swoole_http_server.pid'
+            # can be one of: (default) auto, debug, trace, info, notice, warning, error
+            #   - auto: when debug set to debug, when not set to notice
+            #   - {debug,trace,info,notice,warning,error}: see swoole configuration
+            
+            log_file: '%kernel.logs_dir%/swoole_%kernel.environment%.log'
+            pid_file: /var/run/swoole_http_server.pid
+            
+            buffer_output_size: 2097152 
+            # in bytes, 2097152b = 2 MiB
 ```

--- a/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
@@ -9,11 +9,13 @@ use K911\Swoole\Common\XdebugHandler\XdebugHandler;
 use function K911\Swoole\decode_string_as_set;
 use function K911\Swoole\format_bytes;
 use function K911\Swoole\get_max_memory;
+use K911\Swoole\Server\Config\Socket;
 use K911\Swoole\Server\Configurator\ConfiguratorInterface;
 use K911\Swoole\Server\HttpServer;
 use K911\Swoole\Server\HttpServerConfiguration;
 use K911\Swoole\Server\HttpServerFactory;
 use K911\Swoole\Server\Runtime\BootableInterface;
+use Swoole\Http\Server;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -72,13 +74,16 @@ abstract class AbstractServerStartCommand extends Command
      */
     protected function configure(): void
     {
-        $defaultSocket = $this->serverConfiguration->getDefaultSocket();
-        $this->addOption('host', null, InputOption::VALUE_REQUIRED, 'Host name to listen to.', $defaultSocket->host())
-            ->addOption('port', null, InputOption::VALUE_REQUIRED, 'Range 0-65535. When 0 random available port is chosen.', $defaultSocket->port())
-            ->addOption('serve-static', 's', InputOption::VALUE_NONE, 'Enables serving static content from public directory.')
+        $sockets = $this->serverConfiguration->getSockets();
+        $serverSocket = $sockets->getServerSocket();
+        $this->addOption('host', null, InputOption::VALUE_REQUIRED, 'Host name to bind to. To bind to any host, use: 0.0.0.0', $serverSocket->host())
+            ->addOption('port', null, InputOption::VALUE_REQUIRED, 'Listen for Swoole HTTP Server on this port, when 0 random available port is chosen', $serverSocket->port())
+            ->addOption('serve-static', 's', InputOption::VALUE_NONE, 'Enables serving static content from public directory')
             ->addOption('public-dir', null, InputOption::VALUE_REQUIRED, 'Public directory', $this->getDefaultPublicDir())
             ->addOption('trusted-hosts', null, InputOption::VALUE_REQUIRED, 'Trusted hosts', $this->parameterBag->get('swoole.http_server.trusted_hosts'))
-            ->addOption('trusted-proxies', null, InputOption::VALUE_REQUIRED, 'Trusted proxies', $this->parameterBag->get('swoole.http_server.trusted_proxies'));
+            ->addOption('trusted-proxies', null, InputOption::VALUE_REQUIRED, 'Trusted proxies', $this->parameterBag->get('swoole.http_server.trusted_proxies'))
+            ->addOption('api', null, InputOption::VALUE_NONE, 'Enable API Server')
+            ->addOption('api-port', null, InputOption::VALUE_REQUIRED, 'Listen for API Server on this port', $this->parameterBag->get('swoole.http_server.api.port'));
     }
 
     private function ensureXdebugDisabled(SymfonyStyle $io): void
@@ -138,12 +143,9 @@ abstract class AbstractServerStartCommand extends Command
             exit(1);
         }
 
-        $server = HttpServerFactory::make(
-            $this->serverConfiguration->getDefaultSocket(),
-            $this->serverConfiguration->getRunningMode()
-        );
-        $this->serverConfigurator->configure($server);
-        $this->server->attach($server);
+        $swooleServer = $this->makeSwooleHttpServer();
+        $this->serverConfigurator->configure($swooleServer);
+        $this->server->attach($swooleServer);
 
         // TODO: Lock server configuration here
 //        $this->serverConfiguration->lock();
@@ -151,7 +153,12 @@ abstract class AbstractServerStartCommand extends Command
         $runtimeConfiguration = ['symfonyStyle' => $io] + $this->prepareRuntimeConfiguration($this->serverConfiguration, $input);
         $this->bootManager->boot($runtimeConfiguration);
 
-        $io->success(\sprintf('Swoole HTTP Server started on http://%s', $this->serverConfiguration->getDefaultSocket()->addressPort()));
+        $sockets = $this->serverConfiguration->getSockets();
+        $serverSocket = $sockets->getServerSocket();
+        $io->success(\sprintf('Swoole HTTP Server started on http://%s', $serverSocket->addressPort()));
+        if ($sockets->hasApiSocket()) {
+            $io->success(\sprintf('API Server started on http://%s', $sockets->getApiSocket()->addressPort()));
+        }
         $io->table(['Configuration', 'Values'], $this->prepareConfigurationRowsToPrint($this->serverConfiguration, $runtimeConfiguration));
 
         if ($this->testing) {
@@ -163,6 +170,18 @@ abstract class AbstractServerStartCommand extends Command
         return 0;
     }
 
+    private function makeSwooleHttpServer(): Server
+    {
+        $sockets = $this->serverConfiguration->getSockets();
+        $serverSocket = $sockets->getServerSocket();
+
+        return HttpServerFactory::make(
+            $serverSocket,
+            $this->serverConfiguration->getRunningMode(),
+            ...($sockets->hasApiSocket() ? [$sockets->getApiSocket()] : [])
+        );
+    }
+
     /**
      * @param HttpServerConfiguration $serverConfiguration
      * @param InputInterface          $input
@@ -171,16 +190,26 @@ abstract class AbstractServerStartCommand extends Command
      */
     protected function prepareServerConfiguration(HttpServerConfiguration $serverConfiguration, InputInterface $input): void
     {
+        $sockets = $serverConfiguration->getSockets();
+
         $port = $input->getOption('port');
         $host = $input->getOption('host');
-        Assertion::numeric($port, 'Port must be numeric');
-        Assertion::string($host, 'Host must be string');
 
-        $socket = $serverConfiguration->getDefaultSocket()
+        Assertion::numeric($port, 'Port must be a number.');
+        Assertion::string($host, 'Host must be a string.');
+
+        $newServerSocket = $sockets->getServerSocket()
             ->withPort((int) $port)
             ->withHost($host);
 
-        $serverConfiguration->changeDefaultSocket($socket);
+        $sockets->changeServerSocket($newServerSocket);
+
+        if ((bool) $input->getOption('api') || $sockets->hasApiSocket()) {
+            $apiPort = $input->getOption('api-port');
+            Assertion::numeric($apiPort, 'Port must be a number.');
+
+            $sockets->changeApiSocket(new Socket('0.0.0.0', (int) $apiPort));
+        }
 
         if (\filter_var($input->getOption('serve-static'), FILTER_VALIDATE_BOOLEAN)) {
             $publicDir = $input->getOption('public-dir');

--- a/src/Bridge/Symfony/Bundle/Command/ServerStatusCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStatusCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Bundle\Command;
+
+use Assert\Assertion;
+use K911\Swoole\Server\Api\ApiServerInterface;
+use K911\Swoole\Server\Config\Socket;
+use K911\Swoole\Server\Config\Sockets;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final class ServerStatusCommand extends Command
+{
+    private $apiServer;
+    private $sockets;
+    private $parameterBag;
+    private $testing = false;
+
+    public function __construct(
+        Sockets $sockets,
+        ApiServerInterface $apiServer,
+        ParameterBagInterface $parameterBag
+    ) {
+        $this->apiServer = $apiServer;
+        $this->sockets = $sockets;
+        $this->parameterBag = $parameterBag;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Get current status of the Swoole HTTP Server by querying running API Server.')
+            ->addOption('api-host', null, InputOption::VALUE_REQUIRED, 'API Server listens on this host.', $this->parameterBag->get('swoole.http_server.api.host'))
+            ->addOption('api-port', null, InputOption::VALUE_REQUIRED, 'API Server listens on this port.', $this->parameterBag->get('swoole.http_server.api.port'));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $this->prepareClientConfiguration($input);
+
+        $this->goAndWait(function () use ($io): void {
+            try {
+                $status = $this->apiServer->status();
+                $metrics = $this->apiServer->metrics();
+            } catch (\RuntimeException $runtimeException) {
+                $io->error('Could not connect to Swoole API Server');
+
+                return;
+            }
+            $io->success('Fetched status and metrics');
+            $this->showStatus($io, $status);
+            $this->showMetrics($io, $metrics);
+        });
+
+        return 0;
+    }
+
+    public function goAndWait(callable $callback): void
+    {
+        if ($this->testing) {
+            $callback();
+
+            return;
+        }
+
+        \go($callback);
+        \swoole_event_wait();
+    }
+
+    private function showStatus(SymfonyStyle $io, array $status): void
+    {
+        $server = $status['server'];
+        $processes = $server['processes'];
+
+        $rows = [
+            ['Host', $server['host']],
+            ['Port', $server['port']],
+            ['Running mode', $server['runningMode']],
+            ['Master PID', $processes['master']['pid']],
+            ['Manager PID', $processes['manager']['pid']],
+            [\sprintf('Worker[%d] PID', $processes['worker']['id']), $processes['worker']['pid']],
+        ];
+
+        foreach ($server['listeners'] as $id => ['host' => $host, 'port' => $port]) {
+            $rows[] = [\sprintf('Listener[%d] Host', $id), $host];
+            $rows[] = [\sprintf('Listener[%d] Port', $id), $port];
+        }
+
+        $io->table([
+            'Configuration', 'Value',
+        ], $rows);
+    }
+
+    private function showMetrics(SymfonyStyle $io, array $metrics): void
+    {
+        $date = \DateTimeImmutable::createFromFormat(DATE_ATOM, $metrics['date']);
+        Assertion::isInstanceOf($date, \DateTimeImmutable::class);
+        $server = $metrics['server'];
+        $runningSeconds = $date->getTimestamp() - $server['start_time'];
+
+        $idleWorkers = $server['idle_worker_num'];
+        $workers = $server['worker_num'];
+        $activeWorkers = $workers - $idleWorkers;
+
+        $io->table([
+            'Metric', 'Quantity', 'Unit',
+        ], [
+            ['Requests', $server['request_count'], '1'],
+            ['Up time', $runningSeconds, 'Seconds'],
+            ['Active connections', $server['connection_num'], '1'],
+            ['Accepted connections', $server['accept_count'], '1'],
+            ['Closed connections', $server['close_count'], '1'],
+            ['Active workers', $activeWorkers, '1'],
+            ['Idle workers', $idleWorkers, '1'],
+        ]);
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    protected function prepareClientConfiguration(InputInterface $input): void
+    {
+        $host = $input->getOption('api-host');
+        $port = $input->getOption('api-port');
+
+        Assertion::numeric($port, 'Port must be a number.');
+        Assertion::string($host, 'Host must be a string.');
+
+        $this->sockets->changeApiSocket(new Socket($host, (int) $port));
+    }
+
+    public function enableTestMode(): void
+    {
+        $this->testing = true;
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -82,6 +82,34 @@ final class Configuration implements ConfigurationInterface
                             ->treatFalseLike('off')
                             ->values(['off', 'auto', 'inotify'])
                         ->end()
+                        ->arrayNode('api')
+                            ->addDefaultsIfNotSet()
+                            ->beforeNormalization()
+                                ->ifTrue(function ($v): bool {
+                                    return \is_string($v) || \is_bool($v) || \is_numeric($v) || null === $v;
+                                })
+                                ->then(function ($v): array {
+                                    return [
+                                        'enabled' => (bool) $v,
+                                        'host' => '0.0.0.0',
+                                        'port' => 9200,
+                                    ];
+                                })
+                            ->end()
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->defaultFalse()
+                                ->end()
+                                ->scalarNode('host')
+                                    ->cannotBeEmpty()
+                                    ->defaultValue('0.0.0.0')
+                                ->end()
+                                ->scalarNode('port')
+                                    ->cannotBeEmpty()
+                                    ->defaultValue(9200)
+                                ->end()
+                            ->end()
+                        ->end()
                         ->arrayNode('static')
                             ->addDefaultsIfNotSet()
                             ->beforeNormalization()

--- a/src/Bridge/Symfony/Bundle/Resources/config/commands.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/commands.yaml
@@ -4,6 +4,11 @@ services:
         autoconfigure: true
         public: false
 
+    'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStatusCommand':
+        tags: [ { name: console.command, command: 'swoole:server:status' } ]
+        arguments:
+            $apiServer: '@K911\Swoole\Server\Api\ApiServerClient'
+
     'K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStopCommand':
         tags: [ { name: console.command, command: 'swoole:server:stop' } ]
 

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
@@ -49,6 +49,18 @@ services:
     'K911\Swoole\Server\LifecycleHandler\ServerManagerStopHandlerInterface':
         class: K911\Swoole\Server\LifecycleHandler\NoOpServerManagerStopHandler
 
+    'K911\Swoole\Server\Api\ApiServerClient':
+
+    'K911\Swoole\Server\Api\ApiServerInterface':
+        class: K911\Swoole\Server\Api\ApiServer
+
+#  Could be helpful for projects that uses/have included proxy-manager
+#        lazy: true
+#        tags:
+#            - { name: proxy, interface: K911\Swoole\Server\Api\ApiServerInterface }
+
+    'K911\Swoole\Server\Config\Sockets':
+
     'K911\Swoole\Server\HttpServerConfiguration':
 
     'K911\Swoole\Server\Configurator\WithHttpServerConfiguration':
@@ -64,6 +76,15 @@ services:
     'K911\Swoole\Server\Configurator\WithWorkerStartHandler':
 
     'K911\Swoole\Server\Configurator\CallableChainConfiguratorFactory':
+
+    'K911\Swoole\Server\Api\WithApiServerConfiguration':
+        arguments:
+            $requestHandler: '@swoole_bundle.server.api_server.request_handler'
+
+    'K911\Swoole\Server\Api\ApiServerRequestHandler':
+
+    'swoole_bundle.server.api_server.request_handler':
+        alias: K911\Swoole\Server\Api\ApiServerRequestHandler
 
     'swoole_bundle.server.http_server.configurator_collection':
         class: K911\Swoole\Component\GeneratedCollection

--- a/src/Client/Http.php
+++ b/src/Client/Http.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Client;
+
+final class Http
+{
+    public const METHOD_GET = 'GET';
+    public const METHOD_HEAD = 'HEAD';
+    public const METHOD_POST = 'POST';
+    public const METHOD_DELETE = 'DELETE';
+    public const METHOD_PATCH = 'PATCH';
+    public const METHOD_TRACE = 'TRACE';
+    public const METHOD_OPTIONS = 'OPTIONS';
+
+    public const HEADER_CONTENT_TYPE = 'content-type';
+    public const HEADER_ACCEPT = 'accept';
+
+    public const CONTENT_TYPE_APPLICATION_JSON = 'application/json';
+    public const CONTENT_TYPE_TEXT_PLAIN = 'text/plain';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Server/Api/ApiServer.php
+++ b/src/Server/Api/ApiServer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Api;
+
+use K911\Swoole\Server\HttpServer;
+use K911\Swoole\Server\HttpServerConfiguration;
+use Swoole\Server\Port;
+
+/**
+ * API Server for Swoole HTTP Server. If enabled, is running on another port, than regular server.
+ * Used to control original Swoole HTTP Server.
+ */
+final class ApiServer implements ApiServerInterface
+{
+    private $server;
+    private $serverConfiguration;
+
+    public function __construct(HttpServer $server, HttpServerConfiguration $serverConfiguration)
+    {
+        $this->server = $server;
+        $this->serverConfiguration = $serverConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function metrics(): array
+    {
+        return [
+            'date' => (new \DateTimeImmutable('now'))->format(\DATE_ATOM),
+            'server' => $this->server->metrics(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shutdown(): void
+    {
+        $this->server->shutdown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reload(): void
+    {
+        $this->server->reload();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function status(): array
+    {
+        $swooleServer = $this->server->getServer();
+
+        return [
+            'date' => \date(\DATE_ATOM),
+            'server' => [
+                'host' => $swooleServer->host,
+                'port' => $swooleServer->port,
+                'runningMode' => $this->serverConfiguration->getRunningMode(),
+                'processes' => $this->extractProcessesStatus($this->server),
+                'settings' => $swooleServer->setting,
+                'listeners' => $this->extractListenersStatus($this->server),
+            ],
+        ];
+    }
+
+    private function extractListenersStatus(HttpServer $server): array
+    {
+        return \array_values(\array_map(function (Port $listener): array {
+            return [
+                'host' => \property_exists($listener, 'host') ? $listener->host : '-',
+                'port' => $listener->port,
+            ];
+        }, $server->getListeners()));
+    }
+
+    private function extractProcessesStatus(HttpServer $server): array
+    {
+        $swooleServer = $server->getServer();
+
+        return [
+            'master' => [
+                'pid' => $swooleServer->master_pid,
+            ],
+            'manager' => [
+                'pid' => $swooleServer->manager_pid,
+            ],
+            'worker' => [
+                'id' => $swooleServer->worker_id,
+                'pid' => $swooleServer->worker_pid,
+            ],
+        ];
+    }
+}

--- a/src/Server/Api/ApiServerClient.php
+++ b/src/Server/Api/ApiServerClient.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Api;
+
+use Assert\Assertion;
+use K911\Swoole\Client\Http;
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Server\Config\Sockets;
+use Swoole\Coroutine\Http\Client;
+
+final class ApiServerClient implements ApiServerInterface
+{
+    /**
+     * @var HttpClient|null
+     */
+    private $client;
+    private $sockets;
+
+    public function __construct(Sockets $sockets)
+    {
+        $this->sockets = $sockets;
+    }
+
+    /**
+     * Get Swoole HTTP Server status.
+     *
+     * @return array
+     */
+    public function status(): array
+    {
+        return $this->getClient()->send('/api/server')['response']['body'];
+    }
+
+    /**
+     * Shutdown Swoole HTTP Server.
+     */
+    public function shutdown(): void
+    {
+        $this->getClient()->send('/api/server', Http::METHOD_DELETE);
+    }
+
+    /**
+     * Reload Swoole HTTP Server workers.
+     */
+    public function reload(): void
+    {
+        $this->getClient()->send('/api/server', Http::METHOD_PATCH);
+    }
+
+    /**
+     * Get Swoole HTTP Server metrics.
+     *
+     * @return array
+     */
+    public function metrics(): array
+    {
+        return $this->getClient()->send('/api/server/metrics')['response']['body'];
+    }
+
+    private function getClient(): HttpClient
+    {
+        if (!$this->client instanceof HttpClient) {
+            $this->client = $this->newClient($this->sockets);
+        }
+
+        return $this->client;
+    }
+
+    private function newClient(Sockets $sockets): HttpClient
+    {
+        Assertion::true($sockets->hasApiSocket(), 'Swoole HTTP Server is not configured properly. To access API trough HTTP interface, you must enable and provide proper address of configured API Server.');
+        $apiSocket = $sockets->getApiSocket();
+
+        $swooleClient = new Client($apiSocket->host(), $apiSocket->port(), $apiSocket->ssl());
+
+        return new HttpClient($swooleClient);
+    }
+}

--- a/src/Server/Api/ApiServerInterface.php
+++ b/src/Server/Api/ApiServerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Api;
+
+interface ApiServerInterface
+{
+    /**
+     * Get Swoole HTTP Server status.
+     *
+     * @return array
+     */
+    public function status(): array;
+
+    /**
+     * Shutdown Swoole HTTP Server.
+     */
+    public function shutdown(): void;
+
+    /**
+     * Reload Swoole HTTP Server workers.
+     */
+    public function reload(): void;
+
+    /**
+     * Get Swoole HTTP Server metrics.
+     *
+     * @return array
+     */
+    public function metrics(): array;
+}

--- a/src/Server/Api/ApiServerRequestHandler.php
+++ b/src/Server/Api/ApiServerRequestHandler.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Api;
+
+use K911\Swoole\Client\Http;
+use K911\Swoole\Server\RequestHandler\RequestHandlerInterface;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Throwable;
+
+final class ApiServerRequestHandler implements RequestHandlerInterface
+{
+    private $routes;
+
+    private const SUPPORTED_HTTP_METHODS = [
+        Http::METHOD_HEAD,
+        Http::METHOD_GET,
+        Http::METHOD_POST,
+        Http::METHOD_PATCH,
+        Http::METHOD_DELETE,
+    ];
+
+    public function __construct(ApiServerInterface $apiServer)
+    {
+        $this->routes = [
+            '/healthz' => [
+                Http::METHOD_GET => $this->composeSimpleRouteDefinition(200, function (): array {
+                    return ['ok' => true];
+                }),
+            ],
+            '/api' => [
+                Http::METHOD_GET => $this->composeSimpleRouteDefinition(200, [$this, 'getRouteMap']),
+            ],
+            '/api/server' => [
+                Http::METHOD_GET => $this->composeSimpleRouteDefinition(200, [$apiServer, 'status']),
+                Http::METHOD_PATCH => $this->composeSimpleRouteDefinition(204, [$apiServer, 'reload']),
+                Http::METHOD_DELETE => $this->composeSimpleRouteDefinition(204, [$apiServer, 'shutdown']),
+            ],
+            '/api/server/metrics' => [
+                Http::METHOD_GET => $this->composeSimpleRouteDefinition(200, [$apiServer, 'metrics']),
+            ],
+        ];
+    }
+
+    private function composeSimpleRouteDefinition(int $code, callable $handler): array
+    {
+        return [
+            'code' => $code,
+            'handler' => $handler,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function handle(Request $request, Response $response): void
+    {
+        try {
+            [$method] = $this->parseRequestInfo($request);
+            switch ($method) {
+                case Http::METHOD_HEAD:
+                    $request->server['request_method'] = Http::METHOD_GET;
+                    $this->sendResponse($response, $this->handleRequest($request)[0]);
+                    break;
+                case Http::METHOD_GET:
+                case Http::METHOD_POST:
+                case Http::METHOD_PATCH:
+                case Http::METHOD_DELETE:
+                    [$statusCode, $data] = $this->handleRequest($request);
+                    $this->sendResponse($response, $statusCode, $data);
+
+                    return;
+                default:
+                    $this->sendResponse($response, 405, [
+                        'error' => \sprintf('Method "%s" is not supported. Supported ones are: %s.', $method, \implode(', ', self::SUPPORTED_HTTP_METHODS)),
+                    ]);
+
+                    return;
+            }
+        } catch (Throwable $exception) {
+            $this->sendErrorExceptionResponse($response, $exception);
+        }
+    }
+
+    private function sendErrorExceptionResponse(Response $response, Throwable $exception): void
+    {
+        $this->sendResponse($response, 500, [
+            'error' => $exception->getMessage(),
+            'code' => $exception->getCode(),
+            'line' => $exception->getLine(),
+            'file' => $exception->getFile(),
+            'trace' => \explode("\n", $exception->getTraceAsString()),
+        ]);
+    }
+
+    private function parseRequestInfo(Request $request): array
+    {
+        $method = \mb_strtoupper($request->server['request_method']);
+        $path = \mb_strtolower(\rtrim($request->server['path_info'], '/'));
+        $path = '' === $path ? '/' : $path;
+
+        return [$method, $path];
+    }
+
+    private function handleRequest(Request $request): array
+    {
+        [$method, $path] = $this->parseRequestInfo($request);
+
+        if (\array_key_exists($path, $this->routes)) {
+            $route = $this->routes[$path];
+            if (\array_key_exists($method, $route)) {
+                $action = $route[$method];
+
+                return [$action['code'], $action['handler']($request)];
+            }
+
+            return [405, [
+                'error' => \sprintf('Method %s for route %s is not valid. Supported ones are: %s.', $method, $path, \implode(', ', \array_keys($route))),
+            ]];
+        }
+
+        return [404, [
+            'error' => \sprintf('Route %s does not exists.', $path),
+            'routes' => $this->getRouteMap(),
+        ]];
+    }
+
+    private function getRouteMap(): array
+    {
+        return \array_map(function (array $route): array {
+            return \array_keys($route);
+        }, $this->routes);
+    }
+
+    private function sendResponse(Response $response, int $statusCode = 200, ?array $data = []): void
+    {
+        if (empty($data) || 204 === $statusCode) {
+            $response->status(200 === $statusCode ? 204 : $statusCode);
+            $response->end();
+
+            return;
+        }
+
+        $response->header(Http::HEADER_CONTENT_TYPE, Http::CONTENT_TYPE_APPLICATION_JSON);
+        $response->status($statusCode);
+
+        $options = \defined('JSON_THROW_ON_ERROR') ? \JSON_THROW_ON_ERROR : 0;
+        $json = \json_encode($data, $options);
+
+        // TODO: Drop on PHP 7.3 Migration
+        if (!\defined('JSON_THROW_ON_ERROR') && false === $json) {
+            throw new \RuntimeException(\json_last_error_msg(), \json_last_error());
+        }
+
+        $response->end($json);
+    }
+}

--- a/src/Server/Api/WithApiServerConfiguration.php
+++ b/src/Server/Api/WithApiServerConfiguration.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Api;
+
+use K911\Swoole\Server\Config\Sockets;
+use K911\Swoole\Server\Configurator\ConfiguratorInterface;
+use K911\Swoole\Server\RequestHandler\RequestHandlerInterface;
+use Swoole\Http\Server;
+
+/**
+ * @internal This class will be dropped, once named server listeners will be implemented
+ */
+final class WithApiServerConfiguration implements ConfiguratorInterface
+{
+    private $sockets;
+    private $requestHandler;
+
+    public function __construct(Sockets $sockets, RequestHandlerInterface $requestHandler)
+    {
+        $this->sockets = $sockets;
+        $this->requestHandler = $requestHandler;
+    }
+
+    /**
+     * @param Server $server
+     */
+    public function configure(Server $server): void
+    {
+        if (!$this->sockets->hasApiSocket()) {
+            return;
+        }
+
+        $apiSocketPort = $this->sockets->getApiSocket()->port();
+        foreach ($server->ports as $port) {
+            if ($port->port === $apiSocketPort) {
+                $port->on('request', [$this->requestHandler, 'handle']);
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Server/Config/Sockets.php
+++ b/src/Server/Config/Sockets.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Config;
+
+use Assert\Assertion;
+use Generator;
+
+final class Sockets
+{
+    private $serverSocket;
+    private $additionalSockets;
+
+    /**
+     * @var Socket|null
+     */
+    private $apiSocket;
+
+    public function __construct(Socket $serverSocket, ?Socket $apiSocket = null, Socket ...$additionalSockets)
+    {
+        $this->serverSocket = $serverSocket;
+        $this->apiSocket = $apiSocket;
+        $this->additionalSockets = $additionalSockets;
+    }
+
+    public function changeServerSocket(Socket $socket): void
+    {
+        $this->serverSocket = $socket;
+    }
+
+    public function getServerSocket(): Socket
+    {
+        return $this->serverSocket;
+    }
+
+    public function getApiSocket(): Socket
+    {
+        Assertion::isInstanceOf($this->apiSocket, Socket::class, 'API Socket is not defined.');
+
+        return $this->apiSocket;
+    }
+
+    public function hasApiSocket(): bool
+    {
+        return $this->apiSocket instanceof Socket;
+    }
+
+    public function disableApiSocket(): void
+    {
+        $this->apiSocket = null;
+    }
+
+    public function changeApiSocket(Socket $socket): void
+    {
+        $this->apiSocket = $socket;
+    }
+
+    /**
+     * Get sockets in order:
+     * - first server socket
+     * - next if defined api socket
+     * - rest of sockets.
+     *
+     * @return Generator
+     */
+    public function getAll(): Generator
+    {
+        yield $this->serverSocket;
+
+        if ($this->hasApiSocket()) {
+            yield $this->apiSocket;
+        }
+
+        yield from $this->additionalSockets;
+    }
+}

--- a/src/Server/Configurator/WithHttpServerConfiguration.php
+++ b/src/Server/Configurator/WithHttpServerConfiguration.php
@@ -23,9 +23,9 @@ final class WithHttpServerConfiguration implements ConfiguratorInterface
     {
         $server->set($this->configuration->getSwooleSettings());
 
-        $defaultSocket = $this->configuration->getDefaultSocket();
+        $defaultSocket = $this->configuration->getServerSocket();
         if (0 === $defaultSocket->port()) {
-            $this->configuration->changeDefaultSocket($defaultSocket->withPort($server->port));
+            $this->configuration->changeServerSocket($defaultSocket->withPort($server->port));
         }
     }
 }

--- a/src/Server/HttpServerConfiguration.php
+++ b/src/Server/HttpServerConfiguration.php
@@ -6,6 +6,7 @@ namespace K911\Swoole\Server;
 
 use Assert\Assertion;
 use K911\Swoole\Server\Config\Socket;
+use K911\Swoole\Server\Config\Sockets;
 
 final class HttpServerConfiguration
 {
@@ -42,26 +43,27 @@ final class HttpServerConfiguration
         'error' => SWOOLE_LOG_ERROR,
     ];
 
-    private $defaultSocket;
+    private $sockets;
     private $runningMode;
     private $settings;
 
     /**
-     * @param Socket $defaultSocket
-     * @param string $runningMode
-     * @param array  $settings      settings available:
-     *                              - reactor_count (default: number of cpu cores)
-     *                              - worker_count (default: 2 * number of cpu cores)
-     *                              - serve_static_files (default: false)
-     *                              - public_dir (default: '%kernel.root_dir%/public')
-     *                              - buffer_output_size (default: '2097152' unit in byte (2MB))
+     * @param Sockets $sockets
+     * @param string  $runningMode
+     * @param array   $settings    settings available:
+     *                             - reactor_count (default: number of cpu cores)
+     *                             - worker_count (default: 2 * number of cpu cores)
+     *                             - serve_static_files (default: false)
+     *                             - public_dir (default: '%kernel.root_dir%/public')
+     *                             - buffer_output_size (default: '2097152' unit in byte (2MB))
      *
      * @throws \Assert\AssertionFailedException
      */
-    public function __construct(Socket $defaultSocket, string $runningMode = 'process', array $settings = [])
+    public function __construct(Sockets $sockets, string $runningMode = 'process', array $settings = [])
     {
+        $this->sockets = $sockets;
+
         $this->changeRunningMode($runningMode);
-        $this->changeDefaultSocket($defaultSocket);
         $this->initializeSettings($settings);
     }
 
@@ -75,9 +77,14 @@ final class HttpServerConfiguration
     /**
      * @param Socket $socket
      */
-    public function changeDefaultSocket(Socket $socket): void
+    public function changeServerSocket(Socket $socket): void
     {
-        $this->defaultSocket = $socket;
+        $this->sockets->changeServerSocket($socket);
+    }
+
+    public function getSockets(): Sockets
+    {
+        return $this->sockets;
     }
 
     /**
@@ -237,9 +244,9 @@ final class HttpServerConfiguration
         return $this->settings['worker_count'];
     }
 
-    public function getDefaultSocket(): Socket
+    public function getServerSocket(): Socket
     {
-        return $this->defaultSocket;
+        return $this->sockets->getServerSocket();
     }
 
     /**

--- a/tests/Feature/SwooleServerReloadCommandTest.php
+++ b/tests/Feature/SwooleServerReloadCommandTest.php
@@ -24,7 +24,7 @@ final class SwooleServerReloadCommandTest extends ServerTestCase
             '--port=9999',
         ]);
 
-        if ($this->coverageEnabled()) {
+        if (self::coverageEnabled()) {
             $serverStart->disableOutput();
         }
         $serverStart->setTimeout(3);
@@ -54,7 +54,7 @@ final class SwooleServerReloadCommandTest extends ServerTestCase
             $this->assertNotSame($expectedResponse, $response2['body']);
 
             $this->runSwooleServerReload();
-            Coroutine::sleep($this->coverageEnabled() ? 3 : 1);
+            Coroutine::sleep(self::coverageEnabled() ? 3 : 1);
 
             $response3 = $client->send('/test/replaced/content')['response'];
 
@@ -67,7 +67,7 @@ final class SwooleServerReloadCommandTest extends ServerTestCase
     {
         $serverReload = $this->createConsoleProcess(['swoole:server:reload']);
 
-        if ($this->coverageEnabled()) {
+        if (self::coverageEnabled()) {
             $serverReload->disableOutput();
         }
         $serverReload->setTimeout(3);
@@ -77,7 +77,7 @@ final class SwooleServerReloadCommandTest extends ServerTestCase
             throw new ProcessFailedException($serverReload);
         }
 
-        if (!$this->coverageEnabled()) {
+        if (!self::coverageEnabled()) {
             $this->assertStringContainsString('Swoole HTTP Server\'s workers reloaded successfully', $serverReload->getOutput());
         }
     }

--- a/tests/Feature/SwooleServerReloadViaApiClientTest.php
+++ b/tests/Feature/SwooleServerReloadViaApiClientTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Server\Api\ApiServerClient;
+use K911\Swoole\Server\Config\Socket;
+use K911\Swoole\Server\Config\Sockets;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+use Swoole\Coroutine;
+
+final class SwooleServerReloadViaApiClientTest extends ServerTestCase
+{
+    private const CONTROLLER_TEMPLATE_ORIGINAL_TEXT = 'Wrong response!';
+    private const CONTROLLER_TEMPLATE_REPLACE_TEXT = '%REPLACE%';
+    private const CONTROLLER_TEMPLATE_SRC = __DIR__.'/../Fixtures/Symfony/TestBundle/Controller/ReplacedContentTestController.php.tmpl';
+    private const CONTROLLER_TEMPLATE_DEST = __DIR__.'/../Fixtures/Symfony/TestBundle/Controller/ReplacedContentTestController.php';
+
+    public function testStartRequestApiToReloadCallStop(): void
+    {
+        static::bootKernel();
+        $sockets = static::$container->get(Sockets::class);
+        $sockets->changeApiSocket(new Socket('0.0.0.0', 9998));
+        $apiClient = static::$container->get(ApiServerClient::class);
+
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+            '--api',
+            '--api-port=9998',
+        ]);
+
+        if (self::coverageEnabled()) {
+            $serverStart->disableOutput();
+        }
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        $this->assertTrue($serverStart->isSuccessful());
+
+        $this->goAndWait(function () use ($apiClient): void {
+            $this->deferServerStop();
+            $this->deferRestoreOriginalTemplateControllerResponse();
+
+            $serverClient = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($serverClient->connect());
+
+            $response1 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response1['statusCode']);
+            $this->assertSame('Wrong response!', $response1['body']);
+
+            $expectedResponse = 'Hello world from reloaded server worker via HTTP API!';
+            $this->replaceContentInTestController($expectedResponse);
+            $this->assertTestControllerResponseEquals($expectedResponse);
+
+            $response2 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response2['statusCode']);
+            $this->assertNotSame($expectedResponse, $response2['body']);
+
+            $apiClient->reload();
+            Coroutine::sleep(self::coverageEnabled() ? 3 : 1);
+
+            $response3 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response3['statusCode']);
+            $this->assertSame($expectedResponse, $response3['body']);
+        });
+    }
+
+    public function testStartRequestApiToReloadCallStopUsingApiEnv(): void
+    {
+        static::bootKernel(['environment' => 'api']);
+        $apiClient = static::$container->get(ApiServerClient::class);
+
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'api']);
+
+        if (self::coverageEnabled()) {
+            $serverStart->disableOutput();
+        }
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        $this->assertTrue($serverStart->isSuccessful());
+
+        $this->goAndWait(function () use ($apiClient): void {
+            $this->deferServerStop();
+            $this->deferRestoreOriginalTemplateControllerResponse();
+
+            $serverClient = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($serverClient->connect());
+
+            $response1 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response1['statusCode']);
+            $this->assertSame('Wrong response!', $response1['body']);
+
+            $expectedResponse = 'Hello world from reloaded server worker via HTTP API!';
+            $this->replaceContentInTestController($expectedResponse);
+            $this->assertTestControllerResponseEquals($expectedResponse);
+
+            $response2 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response2['statusCode']);
+            $this->assertNotSame($expectedResponse, $response2['body']);
+
+            $apiClient->reload();
+            Coroutine::sleep(self::coverageEnabled() ? 3 : 1);
+
+            $response3 = $serverClient->send('/test/replaced/content')['response'];
+
+            $this->assertSame(200, $response3['statusCode']);
+            $this->assertSame($expectedResponse, $response3['body']);
+        });
+    }
+
+    private function replaceContentInTestController(string $text): void
+    {
+        \file_put_contents(
+            self::CONTROLLER_TEMPLATE_DEST,
+            \str_replace(self::CONTROLLER_TEMPLATE_REPLACE_TEXT, $text, \file_get_contents(self::CONTROLLER_TEMPLATE_SRC))
+        );
+    }
+
+    private function assertTestControllerResponseEquals(string $expected): void
+    {
+        $this->assertSame(
+            \str_replace(self::CONTROLLER_TEMPLATE_REPLACE_TEXT, $expected, \file_get_contents(self::CONTROLLER_TEMPLATE_SRC)),
+            \file_get_contents(self::CONTROLLER_TEMPLATE_DEST)
+        );
+    }
+
+    private function deferRestoreOriginalTemplateControllerResponse(): void
+    {
+        \defer(function (): void {
+            $this->replaceContentInTestController(self::CONTROLLER_TEMPLATE_ORIGINAL_TEXT);
+        });
+    }
+}

--- a/tests/Feature/SwooleServerRunCommandTest.php
+++ b/tests/Feature/SwooleServerRunCommandTest.php
@@ -17,7 +17,7 @@ final class SwooleServerRunCommandTest extends ServerTestCase
             '--port=9999',
         ]);
 
-        if ($this->coverageEnabled()) {
+        if (self::coverageEnabled()) {
             $serverRun->disableOutput();
         }
         $serverRun->setTimeout(10);

--- a/tests/Feature/SwooleServerStartStopCommandTest.php
+++ b/tests/Feature/SwooleServerStartStopCommandTest.php
@@ -17,7 +17,7 @@ final class SwooleServerStartStopCommandTest extends ServerTestCase
             '--port=9999',
         ]);
 
-        if ($this->coverageEnabled()) {
+        if (self::coverageEnabled()) {
             $serverStart->disableOutput();
         }
         $serverStart->setTimeout(3);

--- a/tests/Feature/SwooleServerStatusCommandTest.php
+++ b/tests/Feature/SwooleServerStatusCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Bridge\Symfony\Bundle\Command\ServerStatusCommand;
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class SwooleServerStatusCommandTest extends ServerTestCase
+{
+    public function testCheckServerStatus(): void
+    {
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+            '--api',
+            '--api-port=9998',
+        ]);
+
+        if (self::coverageEnabled()) {
+            $serverStart->disableOutput();
+        }
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        $this->assertTrue($serverStart->isSuccessful());
+
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+
+        /** @var ServerStatusCommand $command */
+        $command = $application->find('swoole:server:status');
+        $command->enableTestMode();
+        $commandTester = new CommandTester($command);
+
+        $this->goAndWait(function () use ($command, $commandTester): void {
+            $this->deferServerStop();
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $commandTester->execute([
+                'command' => $command->getName(),
+                '--api-host' => 'localhost',
+                '--api-port' => '9998',
+            ]);
+
+            $this->assertStringContainsString('Fetched status and metrics', $commandTester->getDisplay());
+            $this->assertStringContainsString('Listener[0] Host', $commandTester->getDisplay());
+            $this->assertStringContainsString('Requests', $commandTester->getDisplay());
+        });
+    }
+}

--- a/tests/Fixtures/Symfony/CoverageBundle/CoverageBundle.php
+++ b/tests/Fixtures/Symfony/CoverageBundle/CoverageBundle.php
@@ -60,6 +60,12 @@ class CoverageBundle extends Bundle
             ->setArgument('$decorated', new Reference(CodeCoverageRequestHandler::class.'.inner'))
             ->setDecoratedService(RequestHandlerInterface::class, null, -9999);
 
+        $container->autowire('swoole_bundle.server.api_server.coverage_request_handler', CodeCoverageRequestHandler::class)
+            ->setPublic(false)
+            ->setAutoconfigured(true)
+            ->setArgument('$decorated', new Reference('swoole_bundle.server.api_server.coverage_request_handler.inner'))
+            ->setDecoratedService('swoole_bundle.server.api_server.request_handler', null, -9999);
+
         $container->autowire(CoverageStartOnServerStart::class)
             ->setPublic(false)
             ->setAutoconfigured(true)

--- a/tests/Fixtures/Symfony/app/config/api/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/api/swoole.yaml
@@ -1,0 +1,3 @@
+swoole:
+    http_server:
+        api: true

--- a/tests/Fixtures/Symfony/app/config/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/swoole.yaml
@@ -9,6 +9,5 @@ swoole:
         port: '%env(int:PORT)%'
         host: '%env(HOST)%'
         static: 'auto'
-        hmr: 'off'
         trusted_hosts: '%env(TRUSTED_HOSTS)%'
         trusted_proxies: '%env(TRUSTED_PROXIES)%'

--- a/tests/run-feature-tests-code-coverage.sh
+++ b/tests/run-feature-tests-code-coverage.sh
@@ -12,7 +12,7 @@ for f in ./tests/Feature/*.php; do
     for ((TRY_NO=1; TRY_NO <= MAX_TRIES; TRY_NO++)); do
         echo "[Test $TEST_NO] Try $TRY_NO of $MAX_TRIES";
 
-        vendor/bin/phpunit "$f" --coverage-php "cov/feature-tests-$TEST_NO.cov" --colors=always
+        vendor/bin/phpunit "$f" --process-isolation --coverage-php "cov/feature-tests-$TEST_NO.cov" --colors=always
         TEST_EXIT_CODE=$?
 
         # Make sure server is killed for next test


### PR DESCRIPTION
API Server component will allow to manage Swoole HTTP Server trough HTTP interface.

Command `swoole:server:status` is added to get informations about currently running HTTP server.

Closes #2 