### PR TITLE
refactor(pid): Rename "pid_file" option to "pid-file"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 *
 !/src
 !/tests
+tests/Fixtures/resources
+tests/Fixtures/Symfony/app/var
+!tests/Fixtures/resources/.gitignore
 !composer.json
 !composer.lock
 !phpstan.neon.dist

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[*.pid]
+insert_final_newline = false
+
 [*.{yml,yaml,json}]
 indent_size = 2
 

--- a/src/Bridge/Symfony/Bundle/Command/ServerReloadCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerReloadCommand.php
@@ -38,7 +38,7 @@ final class ServerReloadCommand extends Command
     protected function configure(): void
     {
         $this->setDescription("Reload Swoole HTTP server's workers running in the background. It will reload only classes not loaded before server initialization.")
-            ->addOption('pid_file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
+            ->addOption('pid-file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
     }
 
     /**
@@ -50,7 +50,7 @@ final class ServerReloadCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $this->serverConfiguration->daemonize($input->getOption('pid_file'));
+        $this->serverConfiguration->daemonize($input->getOption('pid-file'));
 
         try {
             $this->server->reload();

--- a/src/Bridge/Symfony/Bundle/Command/ServerStartCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStartCommand.php
@@ -23,7 +23,7 @@ final class ServerStartCommand extends AbstractServerStartCommand
     protected function configure(): void
     {
         $this->setDescription('Run Swoole HTTP server in the background.')
-            ->addOption('pid_file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
+            ->addOption('pid-file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
 
         parent::configure();
     }
@@ -34,7 +34,7 @@ final class ServerStartCommand extends AbstractServerStartCommand
     protected function prepareServerConfiguration(HttpServerConfiguration $serverConfiguration, InputInterface $input): void
     {
         /** @var string|null $pidFile */
-        $pidFile = $input->getOption('pid_file');
+        $pidFile = $input->getOption('pid-file');
         $serverConfiguration->daemonize($pidFile);
 
         parent::prepareServerConfiguration($serverConfiguration, $input);
@@ -45,8 +45,9 @@ final class ServerStartCommand extends AbstractServerStartCommand
      */
     protected function startServer(HttpServerConfiguration $serverConfiguration, HttpServer $server, SymfonyStyle $io): void
     {
-        if (!$serverConfiguration->existsPidFile() && !\touch($serverConfiguration->getPidFile())) {
-            throw new RuntimeException(\sprintf('Could not create pid file "%s".', $serverConfiguration->getPid()));
+        $pidFile = $serverConfiguration->getPidFile();
+        if (!\touch($pidFile) || !\is_writable($pidFile)) {
+            throw new RuntimeException(\sprintf('Could not access or create pid file "%s".', $serverConfiguration->getPidFile()));
         }
 
         $this->closeSymfonyStyle($io);

--- a/src/Bridge/Symfony/Bundle/Command/ServerStopCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStopCommand.php
@@ -38,7 +38,7 @@ final class ServerStopCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Stop Swoole HTTP server running in the background.')
-            ->addOption('pid_file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
+            ->addOption('pid-file', null, InputOption::VALUE_REQUIRED, 'Pid file', $this->parameterBag->get('kernel.project_dir').'/var/swoole.pid');
     }
 
     /**
@@ -50,7 +50,7 @@ final class ServerStopCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $this->serverConfiguration->daemonize($input->getOption('pid_file'));
+        $this->serverConfiguration->daemonize($input->getOption('pid-file'));
 
         try {
             $this->server->shutdown();

--- a/tests/Feature/SwooleCustomPidFileTest.php
+++ b/tests/Feature/SwooleCustomPidFileTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+final class SwooleCustomPidFileTest extends ServerTestCase
+{
+    public function testStartServerOnCustomPidFileLocation(): void
+    {
+        $pidFile = $this->generateNotExistingCustomPidFile();
+
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+            \sprintf('--pid-file=%s', $pidFile),
+        ]);
+
+        $this->assertFileNotExists($pidFile);
+
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        if (!$serverStart->isSuccessful()) {
+            throw new ProcessFailedException($serverStart);
+        }
+
+        $this->goAndWait(function () use ($pidFile): void {
+            $this->deferServerStop(\sprintf('--pid-file=%s', $pidFile));
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $this->assertFileExists($pidFile);
+            $this->assertIsNumeric(\file_get_contents($pidFile));
+
+            $this->assertHelloWorldRequestSucceeded($client);
+        });
+    }
+
+    public function testTryToStartServerOnReadOnlyExistingPidFile(): void
+    {
+        $pidFile = $this->setUpExistingReadOnlyPidFile();
+
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+            \sprintf('--pid-file=%s', $pidFile),
+        ]);
+
+        $this->assertFileExists($pidFile);
+        $this->assertFileNotIsWritable($pidFile);
+
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        $this->assertNotTrue($serverStart->isSuccessful());
+        $this->assertStringContainsString('Could not access or create pid file', $serverStart->getErrorOutput());
+    }
+
+    private function generateNotExistingCustomPidFile(): string
+    {
+        $hash = \bin2hex(\random_bytes(8));
+
+        return \sprintf('%s/custom-pid-file-%s.pid', self::FIXTURE_RESOURCES_DIR, $hash);
+    }
+
+    private function setUpExistingReadOnlyPidFile(): string
+    {
+        $hash = \bin2hex(\random_bytes(8));
+        $readOnlyFile = \sprintf('%s/existing-readonly-pid-file-%s.pid', self::FIXTURE_RESOURCES_DIR, $hash);
+
+        $this->assertNotFalse(\file_put_contents($readOnlyFile, '-9999'));
+        $this->assertTrue(\chmod($readOnlyFile, 0400));
+
+        return $readOnlyFile;
+    }
+}

--- a/tests/Feature/SwooleServerRunCommandTest.php
+++ b/tests/Feature/SwooleServerRunCommandTest.php
@@ -29,14 +29,7 @@ final class SwooleServerRunCommandTest extends ServerTestCase
             $client = HttpClient::fromDomain('localhost', 9999, false);
             $this->assertTrue($client->connect());
 
-            $response = $client->send('/')['response'];
-
-            $this->assertTrue(true);
-
-            $this->assertSame(200, $response['statusCode']);
-            $this->assertSame([
-                'hello' => 'world!',
-            ], $response['body']);
+            $this->assertHelloWorldRequestSucceeded($client);
         });
     }
 }

--- a/tests/Feature/SwooleServerStartStopCommandTest.php
+++ b/tests/Feature/SwooleServerStartStopCommandTest.php
@@ -30,13 +30,7 @@ final class SwooleServerStartStopCommandTest extends ServerTestCase
 
             $client = HttpClient::fromDomain('localhost', 9999, false);
             $this->assertTrue($client->connect());
-
-            $response = $client->send('/')['response'];
-
-            $this->assertSame(200, $response['statusCode']);
-            $this->assertSame([
-                'hello' => 'world!',
-            ], $response['body']);
+            $this->assertHelloWorldRequestSucceeded($client);
         });
     }
 }

--- a/tests/Feature/SwooleServerStatusCommandTest.php
+++ b/tests/Feature/SwooleServerStatusCommandTest.php
@@ -53,6 +53,8 @@ final class SwooleServerStatusCommandTest extends ServerTestCase
             $this->assertStringContainsString('Fetched status and metrics', $commandTester->getDisplay());
             $this->assertStringContainsString('Listener[0] Host', $commandTester->getDisplay());
             $this->assertStringContainsString('Requests', $commandTester->getDisplay());
+
+            $this->assertHelloWorldRequestSucceeded($client);
         });
     }
 }

--- a/tests/Fixtures/Symfony/CoverageBundle/RequestHandler/CodeCoverageRequestHandler.php
+++ b/tests/Fixtures/Symfony/CoverageBundle/RequestHandler/CodeCoverageRequestHandler.php
@@ -25,11 +25,12 @@ final class CodeCoverageRequestHandler implements RequestHandlerInterface
      */
     public function handle(Request $request, Response $response): void
     {
-        $this->codeCoverageManager->start('test_request');
+        $testName = \sprintf('test_request_%s', \bin2hex(\random_bytes(8)));
+        $this->codeCoverageManager->start($testName);
 
         $this->decorated->handle($request, $response);
 
         $this->codeCoverageManager->stop();
-        $this->codeCoverageManager->finish('test_request');
+        $this->codeCoverageManager->finish($testName);
     }
 }

--- a/tests/Fixtures/resources/.gitignore
+++ b/tests/Fixtures/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
To keep consitency in naming