### PR TITLE
fix(static-server): Fix unset public dir path in "AdvancedStaticFilesServer"

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -99,9 +99,8 @@ final class SwooleExtension extends Extension implements PrependExtensionInterfa
         if ('advanced' === $static['strategy']) {
             $container->register(AdvancedStaticFilesServer::class)
                 ->addArgument(new Reference(AdvancedStaticFilesServer::class.'.inner'))
-                ->setAutowired(true)
-                ->setAutoconfigured(true)
-                ->setPublic(false)
+                ->addArgument(new Reference(HttpServerConfiguration::class))
+                ->addTag('swoole_bundle.bootable_service')
                 ->setDecoratedService(RequestHandlerInterface::class, null, -60);
         }
 
@@ -138,9 +137,8 @@ final class SwooleExtension extends Extension implements PrependExtensionInterfa
         }
 
         if ('inotify' === $hmr) {
-            $container->autowire(HotModuleReloaderInterface::class, InotifyHMR::class)
-                ->setAutoconfigured(true)
-                ->setPublic(false);
+            $container->register(HotModuleReloaderInterface::class, InotifyHMR::class)
+                ->addTag('swoole_bundle.bootable_service');
         }
 
         $container->autowire(HMRWorkerStartHandler::class)
@@ -183,9 +181,7 @@ final class SwooleExtension extends Extension implements PrependExtensionInterfa
         if ($config['trust_all_proxies_handler']) {
             $container->register(TrustAllProxiesRequestHandler::class)
                 ->addArgument(new Reference(TrustAllProxiesRequestHandler::class.'.inner'))
-                ->setAutowired(true)
-                ->setAutoconfigured(true)
-                ->setPublic(false)
+                ->addTag('swoole_bundle.bootable_service')
                 ->setDecoratedService(RequestHandlerInterface::class, null, -10);
         }
 

--- a/src/Client/Http.php
+++ b/src/Client/Http.php
@@ -19,6 +19,7 @@ final class Http
 
     public const CONTENT_TYPE_APPLICATION_JSON = 'application/json';
     public const CONTENT_TYPE_TEXT_PLAIN = 'text/plain';
+    public const CONTENT_TYPE_TEXT_HTML = 'text/html';
 
     private function __construct()
     {

--- a/src/Client/HttpClient.php
+++ b/src/Client/HttpClient.php
@@ -32,6 +32,7 @@ final class HttpClient
     private const SUPPORTED_CONTENT_TYPES = [
         Http::CONTENT_TYPE_APPLICATION_JSON,
         Http::CONTENT_TYPE_TEXT_PLAIN,
+        Http::CONTENT_TYPE_TEXT_HTML,
     ];
 
     private const ACCEPTABLE_CONNECTING_EXIT_CODES = [
@@ -211,6 +212,7 @@ final class HttpClient
 
                 return \json_decode($client->body, true, 512, JSON_THROW_ON_ERROR);
             case Http::CONTENT_TYPE_TEXT_PLAIN:
+            case Http::CONTENT_TYPE_TEXT_HTML:
                 return $client->body;
             default:
                 throw UnsupportedContentTypeException::forContentType($contentType, self::SUPPORTED_CONTENT_TYPES);

--- a/tests/Feature/StaticFilesServingTest.php
+++ b/tests/Feature/StaticFilesServingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class StaticFilesServingTest extends ServerTestCase
+{
+    public function testAdvancedStaticFilesServerWithAutoRegistration(): void
+    {
+        $serverRun = $this->createConsoleProcess([
+            'swoole:server:run',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'auto']);
+
+        $serverRun->setTimeout(10);
+        $serverRun->start();
+
+        $this->goAndWait(function () use ($serverRun): void {
+            $this->deferProcessStop($serverRun);
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $response = $client->send('/robots.txt')['response'];
+
+            $this->assertSame(200, $response['statusCode']);
+            $this->assertSame('text/plain', $response['headers']['content-type']);
+            $expectedResponseBody = <<< 'EOF'
+User-agent: *
+Disallow: /
+
+EOF;
+            $this->assertSame($expectedResponseBody, $response['body']);
+        });
+    }
+
+    public function testDefaultSwooleStaticFilesServing(): void
+    {
+        $serverRun = $this->createConsoleProcess([
+            'swoole:server:run',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'static']);
+
+        $serverRun->setTimeout(10);
+        $serverRun->start();
+
+        $this->goAndWait(function () use ($serverRun): void {
+            $this->deferProcessStop($serverRun);
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $response = $client->send('/robots.txt')['response'];
+
+            $this->assertSame(200, $response['statusCode']);
+            $this->assertSame('text/plain', $response['headers']['content-type']);
+            $expectedResponseBody = <<< 'EOF'
+User-agent: *
+Disallow: /
+
+EOF;
+            $this->assertSame($expectedResponseBody, $response['body']);
+        });
+    }
+
+    public function testDisabledStaticFilesServingOnProductionByDefault(): void
+    {
+        $serverRun = $this->createConsoleProcess([
+            'swoole:server:run',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'prod']);
+
+        $serverRun->setTimeout(10);
+        $serverRun->start();
+
+        $this->goAndWait(function () use ($serverRun): void {
+            $this->deferProcessStop($serverRun);
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $response = $client->send('/robots.txt')['response'];
+
+            $this->assertSame(404, $response['statusCode']);
+        });
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Test/ServerTestCase.php
+++ b/tests/Fixtures/Symfony/TestBundle/Test/ServerTestCase.php
@@ -135,6 +135,10 @@ class ServerTestCase extends KernelTestCase
             if (self::coverageEnabled()) {
                 $envs['COVERAGE'] = '1';
                 $envs['APP_ENV'] = self::resolveEnvironment($envs['APP_ENV'] ?? null);
+
+                if (!\array_key_exists('APP_DEBUG', $envs) && 'prod_cov' === $envs['APP_ENV']) {
+                    $envs['APP_DEBUG'] = '0';
+                }
             }
 
             if (!\array_key_exists('SWOOLE_ALLOW_XDEBUG', $envs)) {
@@ -159,6 +163,13 @@ class ServerTestCase extends KernelTestCase
     {
         if (\extension_loaded('xdebug')) {
             $this->markTestSkipped('Test is incompatible with Xdebug extension. Please disable it and try again. To generate code coverage use "pcov" extension.');
+        }
+    }
+
+    protected function markTestSkippedIfInotifyDisabled(): void
+    {
+        if (!\extension_loaded('inotify')) {
+            $this->markTestSkipped('Swoole Bundle HMR requires "inotify" PHP extension present and installed on the system.');
         }
     }
 

--- a/tests/Fixtures/Symfony/app/config/auto/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/auto/swoole.yaml
@@ -1,0 +1,4 @@
+swoole:
+    http_server:
+        static: auto
+        hmr: auto

--- a/tests/Fixtures/Symfony/app/config/static/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/static/swoole.yaml
@@ -1,3 +1,3 @@
 swoole:
     http_server:
-        hmr: 'auto'
+        static: default


### PR DESCRIPTION
A bug caused that "AdvancedStaticFilesServer" was not tagged as bootable service, what resulted in
unsed public directory path.