### PR TITLE
fix(server): Make sure "reactor" running mode works correctly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ indent_size = 2
 [src/Bridge/Symfony/**/*.{yml,yaml}]
 indent_size = 4
 
+[tests/Fixtures/Symfony/app/config/**/*.{yml,yaml}]
+indent_size = 4
+
 [composer.json]
 indent_size = 4
 

--- a/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
@@ -282,7 +282,9 @@ abstract class AbstractServerStartCommand extends Command
         $rows = [
             ['env', $this->parameterBag->get('kernel.environment')],
             ['debug', \var_export($this->parameterBag->get('kernel.debug'), true)],
+            ['running_mode', $serverConfiguration->getRunningMode()],
             ['worker_count', $serverConfiguration->getWorkerCount()],
+            ['reactor_count', $serverConfiguration->getReactorCount()],
             ['memory_limit', format_bytes(get_max_memory())],
             ['trusted_hosts', \implode(', ', $runtimeConfiguration['trustedHosts'])],
         ];

--- a/src/Server/Configurator/WithServerStartHandler.php
+++ b/src/Server/Configurator/WithServerStartHandler.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace K911\Swoole\Server\Configurator;
 
+use K911\Swoole\Server\HttpServerConfiguration;
 use K911\Swoole\Server\LifecycleHandler\ServerStartHandlerInterface;
 use Swoole\Http\Server;
 
 final class WithServerStartHandler implements ConfiguratorInterface
 {
     private $handler;
+    private $configuration;
 
-    public function __construct(ServerStartHandlerInterface $handler)
+    public function __construct(ServerStartHandlerInterface $handler, HttpServerConfiguration $configuration)
     {
         $this->handler = $handler;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -21,6 +24,11 @@ final class WithServerStartHandler implements ConfiguratorInterface
      */
     public function configure(Server $server): void
     {
+        // see: https://github.com/swoole/swoole-src/blob/077c2dfe84d9f2c6d47a4e105f41423421dd4c43/src/server/reactor_process.cc#L181
+        if ($this->configuration->isReactorRunningMode()) {
+            return;
+        }
+
         $server->on('start', [$this->handler, 'handle']);
     }
 }

--- a/src/Server/LifecycleHandler/SigIntHandler.php
+++ b/src/Server/LifecycleHandler/SigIntHandler.php
@@ -10,10 +10,12 @@ use Swoole\Server;
 final class SigIntHandler implements ServerStartHandlerInterface
 {
     private $decorated;
+    private $signalInterrupt;
 
     public function __construct(?ServerStartHandlerInterface $decorated = null)
     {
         $this->decorated = $decorated;
+        $this->signalInterrupt = \defined('SIGINT') ? (int) \constant('SIGINT') : 2;
     }
 
     /**
@@ -22,7 +24,7 @@ final class SigIntHandler implements ServerStartHandlerInterface
     public function handle(Server $server): void
     {
         // 2 => SIGINT
-        Process::signal(2, [$server, 'shutdown']);
+        Process::signal($this->signalInterrupt, [$server, 'shutdown']);
 
         if ($this->decorated instanceof ServerStartHandlerInterface) {
             $this->decorated->handle($server);

--- a/tests/Feature/SwooleServerStartStopCommandTest.php
+++ b/tests/Feature/SwooleServerStartStopCommandTest.php
@@ -9,6 +9,11 @@ use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
 
 final class SwooleServerStartStopCommandTest extends ServerTestCase
 {
+    protected function setUp(): void
+    {
+        $this->markTestSkippedIfXdebugEnabled();
+    }
+
     public function testStartCallStop(): void
     {
         $serverStart = $this->createConsoleProcess([
@@ -17,9 +22,28 @@ final class SwooleServerStartStopCommandTest extends ServerTestCase
             '--port=9999',
         ]);
 
-        if (self::coverageEnabled()) {
-            $serverStart->disableOutput();
-        }
+        $serverStart->setTimeout(3);
+        $serverStart->run();
+
+        $this->assertProcessSucceeded($serverStart);
+
+        $this->goAndWait(function (): void {
+            $this->deferServerStop();
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+            $this->assertHelloWorldRequestSucceeded($client);
+        });
+    }
+
+    public function testStartCallStopOnReactorRunningMode(): void
+    {
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'reactor']);
+
         $serverStart->setTimeout(3);
         $serverStart->run();
 

--- a/tests/Fixtures/Symfony/app/config/reactor/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/reactor/swoole.yaml
@@ -1,0 +1,3 @@
+swoole:
+    http_server:
+        running_mode: reactor

--- a/tests/Fixtures/Symfony/app/config/swoole.yaml
+++ b/tests/Fixtures/Symfony/app/config/swoole.yaml
@@ -8,6 +8,5 @@ swoole:
     http_server:
         port: '%env(int:PORT)%'
         host: '%env(HOST)%'
-        static: 'auto'
         trusted_hosts: '%env(TRUSTED_HOSTS)%'
         trusted_proxies: '%env(TRUSTED_PROXIES)%'

--- a/tests/Unit/Server/Configurator/WithServerStartHandlerTest.php
+++ b/tests/Unit/Server/Configurator/WithServerStartHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace K911\Swoole\Tests\Unit\Server\Configurator;
 
 use K911\Swoole\Server\Configurator\WithServerStartHandler;
+use K911\Swoole\Server\HttpServerConfiguration;
 use K911\Swoole\Server\LifecycleHandler\NoOpServerStartHandler;
 use K911\Swoole\Tests\Unit\Server\SwooleHttpServerMock;
 use PHPUnit\Framework\TestCase;
@@ -24,20 +25,43 @@ class WithServerStartHandlerTest extends TestCase
      */
     private $configurator;
 
+    /**
+     * @var \Prophecy\Prophecy\ObjectProphecy|HttpServerConfiguration
+     */
+    private $httpServerConfigurationMock;
+
     protected function setUp(): void
     {
+        $this->httpServerConfigurationMock = $this->prophesize(HttpServerConfiguration::class);
         $this->noOpServerStartHandler = new NoOpServerStartHandler();
 
-        $this->configurator = new WithServerStartHandler($this->noOpServerStartHandler);
+        $this->configurator = new WithServerStartHandler($this->noOpServerStartHandler, $this->httpServerConfigurationMock->reveal());
     }
 
-    public function testConfigure(): void
+    public function testConfigureNoReactorMode(): void
     {
+        $this->httpServerConfigurationMock->isReactorRunningMode()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
         $swooleServerOnEventSpy = SwooleHttpServerMock::make();
 
         $this->configurator->configure($swooleServerOnEventSpy);
 
         $this->assertTrue($swooleServerOnEventSpy->registeredEvent);
         $this->assertSame(['start', [$this->noOpServerStartHandler, 'handle']], $swooleServerOnEventSpy->registeredEventPair);
+    }
+
+    public function testConfigureReactorMode(): void
+    {
+        $this->httpServerConfigurationMock->isReactorRunningMode()
+            ->willReturn(true)
+            ->shouldBeCalled();
+
+        $swooleServerOnEventSpy = SwooleHttpServerMock::make();
+
+        $this->configurator->configure($swooleServerOnEventSpy);
+
+        $this->assertFalse($swooleServerOnEventSpy->registeredEvent);
     }
 }


### PR DESCRIPTION
Using `swoole:server:run` command with `reactor` running mode caused error regarding setting up signal listener on manager process.

When using `reactor` mode, swoole server event `start` cannot be used due to master process is the same as manager process. Use event `ManagerStart` instead.