### PR TITLE
feat(messenger): Add Symfony Messenger integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     }],
     "require": {
         "php": "^7.2",
-        "ext-swoole": "^4",
+        "ext-swoole": "^4.3.4",
         "beberlei/assert": "^3.0",
-        "symfony/config": "^4.2",
-        "symfony/console": "^4.2",
-        "symfony/process": "^4.2",
-        "symfony/dependency-injection": "^4.2",
-        "symfony/http-foundation": "^4.2",
-        "symfony/http-kernel": "^4.2"
+        "symfony/config": "^4.3.1",
+        "symfony/console": "^4.3.1",
+        "symfony/process": "^4.3.1",
+        "symfony/dependency-injection": "^4.3.1",
+        "symfony/http-foundation": "^4.3.1",
+        "symfony/http-kernel": "^4.3.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.6",
@@ -41,13 +41,14 @@
         "phpunit/phpcov": "^6.0",
         "phpunit/phpunit": "^8.0.4",
         "swoole/ide-helper": "^4.3",
-        "symfony/debug": "^4.2",
-        "symfony/framework-bundle": "^4.2.4",
-        "symfony/monolog-bridge": "^4.2",
+        "symfony/debug": "^4.3.1",
+        "symfony/framework-bundle": "^4.3.1",
+        "symfony/messenger": "^4.3.1",
+        "symfony/monolog-bridge": "^4.3.1",
         "symfony/monolog-bundle": "^3.3",
-        "symfony/twig-bundle": "^4.2",
-        "symfony/var-dumper": "^4.2",
-        "symfony/yaml": "^4.2"
+        "symfony/twig-bundle": "^4.3.1",
+        "symfony/var-dumper": "^4.3.1",
+        "symfony/yaml": "^4.3.1"
     },
     "suggest": {
         "ext-inotify": "To enable HMR.",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9620f3dda7c0b3ee425dd64c98292f1e",
+    "content-hash": "a837a53423e50eddc0b7a1f7a2c2251d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2691,7 +2691,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
+            "description": "? Nette Finder: find files and directories with an intuitive API.",
             "homepage": "https://nette.org",
             "keywords": [
                 "filesystem",
@@ -2751,7 +2751,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",
@@ -5210,6 +5210,80 @@
             "time": "2019-06-06T08:35:06+00:00"
         },
         {
+            "name": "symfony/messenger",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "47d2b91e111da96045208cceb86d4732c39d385e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/47d2b91e111da96045208cceb86d4732c39d385e",
+                "reference": "47d2b91e111da96045208cceb86d4732c39d385e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/debug": "<4.1",
+                "symfony/event-dispatcher": "<4.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.5",
+                "psr/cache": "~1.0",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/debug": "~4.1",
+                "symfony/dependency-injection": "~3.4.19|^4.1.8",
+                "symfony/doctrine-bridge": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~4.3",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/serializer": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.4|~4.0"
+            },
+            "suggest": {
+                "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                }
+            ],
+            "description": "Symfony Messenger Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-06-05T13:18:57+00:00"
+        },
+        {
             "name": "symfony/monolog-bridge",
             "version": "v4.3.1",
             "source": {
@@ -6152,7 +6226,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2",
-        "ext-swoole": "^4"
+        "ext-swoole": "^4.3.4"
     },
     "platform-dev": []
 }

--- a/src/Bridge/Symfony/Bundle/Command/ServerStatusCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStatusCommand.php
@@ -123,8 +123,11 @@ final class ServerStatusCommand extends Command
             ['Active connections', $server['connection_num'], '1'],
             ['Accepted connections', $server['accept_count'], '1'],
             ['Closed connections', $server['close_count'], '1'],
+            ['All workers', $workers, '1'],
             ['Active workers', $activeWorkers, '1'],
             ['Idle workers', $idleWorkers, '1'],
+            ['Running coroutines', $server['coroutine_num'], '1'],
+            ['Tasks in queue', $server['tasking_num'], '1'],
         ]);
     }
 

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -175,6 +175,9 @@ final class Configuration implements ConfigurationInterface
                                 ->integerNode('reactor_count')
                                     ->min(1)
                                 ->end()
+                                ->scalarNode('task_worker_count')
+                                    ->defaultNull()
+                                ->end()
                             ->end()
                         ->end() // settings
                     ->end()

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
@@ -49,6 +49,12 @@ services:
     'K911\Swoole\Server\LifecycleHandler\ServerManagerStopHandlerInterface':
         class: K911\Swoole\Server\LifecycleHandler\NoOpServerManagerStopHandler
 
+    'K911\Swoole\Server\TaskHandler\TaskHandlerInterface':
+        class: K911\Swoole\Server\TaskHandler\NoOpTaskHandler
+
+    'K911\Swoole\Server\TaskHandler\TaskFinishedHandlerInterface':
+        class: K911\Swoole\Server\TaskHandler\NoOpTaskFinishedHandler
+
     'K911\Swoole\Server\Api\ApiServerClientFactory':
 
     'K911\Swoole\Server\Api\ApiServerClient':
@@ -77,6 +83,10 @@ services:
     'K911\Swoole\Server\Configurator\WithServerManagerStopHandler':
 
     'K911\Swoole\Server\Configurator\WithWorkerStartHandler':
+
+    'K911\Swoole\Server\Configurator\WithTaskHandler':
+
+    'K911\Swoole\Server\Configurator\WithTaskFinishedHandler':
 
     'K911\Swoole\Server\Configurator\CallableChainConfiguratorFactory':
 

--- a/src/Bridge/Symfony/Messenger/Exception/ReceiverNotAvailableException.php
+++ b/src/Bridge/Symfony/Messenger/Exception/ReceiverNotAvailableException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger\Exception;
+
+use Symfony\Component\Messenger\Exception\TransportException;
+
+final class ReceiverNotAvailableException extends TransportException
+{
+    public static function make(): self
+    {
+        throw new self('Swoole Server Task transport does not implement Receiver interface methods. Messages sent via Swoole Server Task transport are dispatched inside task worker processes.');
+    }
+}

--- a/src/Bridge/Symfony/Messenger/SwooleServerTaskReceiver.php
+++ b/src/Bridge/Symfony/Messenger/SwooleServerTaskReceiver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger;
+
+use K911\Swoole\Bridge\Symfony\Messenger\Exception\ReceiverNotAvailableException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+final class SwooleServerTaskReceiver implements ReceiverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        throw ReceiverNotAvailableException::make();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        throw ReceiverNotAvailableException::make();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(Envelope $envelope): void
+    {
+        throw ReceiverNotAvailableException::make();
+    }
+}

--- a/src/Bridge/Symfony/Messenger/SwooleServerTaskSender.php
+++ b/src/Bridge/Symfony/Messenger/SwooleServerTaskSender.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger;
+
+use K911\Swoole\Server\HttpServer;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+
+final class SwooleServerTaskSender implements SenderInterface
+{
+    private $httpServer;
+
+    public function __construct(HttpServer $httpServer)
+    {
+        $this->httpServer = $httpServer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        /** @var SentStamp|null $sentStamp */
+        $sentStamp = $envelope->last(SentStamp::class);
+        $alias = null === $sentStamp ? 'swoole-task' : $sentStamp->getSenderAlias() ?? $sentStamp->getSenderClass();
+
+        $this->httpServer->dispatchTask($envelope->with(new ReceivedStamp($alias)));
+
+        return $envelope;
+    }
+}

--- a/src/Bridge/Symfony/Messenger/SwooleServerTaskTransport.php
+++ b/src/Bridge/Symfony/Messenger/SwooleServerTaskTransport.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+final class SwooleServerTaskTransport implements TransportInterface
+{
+    private $receiver;
+    private $sender;
+
+    public function __construct(SwooleServerTaskReceiver $receiver, SwooleServerTaskSender $sender)
+    {
+        $this->receiver = $receiver;
+        $this->sender = $sender;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        return $this->sender->send($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        return $this->receiver->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        $this->receiver->ack($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(Envelope $envelope): void
+    {
+        $this->receiver->reject($envelope);
+    }
+}

--- a/src/Bridge/Symfony/Messenger/SwooleServerTaskTransportFactory.php
+++ b/src/Bridge/Symfony/Messenger/SwooleServerTaskTransportFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger;
+
+use K911\Swoole\Server\HttpServer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+final class SwooleServerTaskTransportFactory implements TransportFactoryInterface
+{
+    private $server;
+
+    public function __construct(HttpServer $server)
+    {
+        $this->server = $server;
+    }
+
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    {
+        return new SwooleServerTaskTransport(
+            new SwooleServerTaskReceiver(),
+            new SwooleServerTaskSender($this->server)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(string $dsn, array $options): bool
+    {
+        return 0 === \mb_strpos($dsn, 'swoole://task');
+    }
+}

--- a/src/Bridge/Symfony/Messenger/SwooleServerTaskTransportHandler.php
+++ b/src/Bridge/Symfony/Messenger/SwooleServerTaskTransportHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Messenger;
+
+use Assert\Assertion;
+use K911\Swoole\Server\TaskHandler\TaskHandlerInterface;
+use Swoole\Server;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class SwooleServerTaskTransportHandler implements TaskHandlerInterface
+{
+    private $bus;
+    private $decorated;
+
+    public function __construct(MessageBusInterface $bus, ?TaskHandlerInterface $decorated = null)
+    {
+        $this->bus = $bus;
+        $this->decorated = $decorated;
+    }
+
+    public function handle(Server $server, int $taskId, int $fromId, $data): void
+    {
+        Assertion::isInstanceOf($data, Envelope::class);
+        /* @var $data Envelope */
+
+        $this->bus->dispatch($data);
+
+        if ($this->decorated instanceof TaskHandlerInterface) {
+            $this->decorated->handle($server, $taskId, $fromId, $data);
+        }
+    }
+}

--- a/src/Client/HttpClient.php
+++ b/src/Client/HttpClient.php
@@ -105,7 +105,6 @@ final class HttpClient
 
         $this->client->setMethod($method);
         $this->client->setHeaders($headers);
-        $this->client->execute($path);
 
         if (null !== $data) {
             if (\is_string($data)) {
@@ -114,6 +113,8 @@ final class HttpClient
                 $this->serializeRequestData($this->client, $data);
             }
         }
+
+        $this->client->execute($path);
 
         return $this->resolveResponse($this->client, $timeout);
     }
@@ -137,7 +138,7 @@ final class HttpClient
             throw new \RuntimeException(\json_last_error_msg(), \json_last_error());
         }
 
-        $client->headers[Http::HEADER_CONTENT_TYPE] = Http::CONTENT_TYPE_APPLICATION_JSON;
+        $client->requestHeaders[Http::HEADER_CONTENT_TYPE] = Http::CONTENT_TYPE_APPLICATION_JSON;
         $client->setData($json);
     }
 

--- a/src/Server/Configurator/WithTaskFinishedHandler.php
+++ b/src/Server/Configurator/WithTaskFinishedHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Configurator;
+
+use K911\Swoole\Server\HttpServerConfiguration;
+use K911\Swoole\Server\TaskHandler\TaskFinishedHandlerInterface;
+use Swoole\Http\Server;
+
+final class WithTaskFinishedHandler implements ConfiguratorInterface
+{
+    private $handler;
+    private $configuration;
+
+    public function __construct(TaskFinishedHandlerInterface $handler, HttpServerConfiguration $configuration)
+    {
+        $this->handler = $handler;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(Server $server): void
+    {
+        if ($this->configuration->getTaskWorkerCount() > 0) {
+            $server->on('finish', [$this->handler, 'handle']);
+        }
+    }
+}

--- a/src/Server/Configurator/WithTaskHandler.php
+++ b/src/Server/Configurator/WithTaskHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\Configurator;
+
+use K911\Swoole\Server\HttpServerConfiguration;
+use K911\Swoole\Server\TaskHandler\TaskHandlerInterface;
+use Swoole\Http\Server;
+
+final class WithTaskHandler implements ConfiguratorInterface
+{
+    private $handler;
+    private $configuration;
+
+    public function __construct(TaskHandlerInterface $handler, HttpServerConfiguration $configuration)
+    {
+        $this->handler = $handler;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(Server $server): void
+    {
+        if ($this->configuration->getTaskWorkerCount() > 0) {
+            $server->on('task', [$this->handler, 'handle']);
+        }
+    }
+}

--- a/src/Server/HttpServer.php
+++ b/src/Server/HttpServer.php
@@ -135,6 +135,11 @@ final class HttpServer
         return $this->server;
     }
 
+    public function dispatchTask($data): void
+    {
+        $this->getServer()->task($data);
+    }
+
     /**
      * @return Listener[]
      */

--- a/src/Server/TaskHandler/NoOpTaskFinishedHandler.php
+++ b/src/Server/TaskHandler/NoOpTaskFinishedHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\TaskHandler;
+
+use Swoole\Server;
+
+final class NoOpTaskFinishedHandler implements TaskFinishedHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Server $server, int $taskId, $data): void
+    {
+        // noop
+    }
+}

--- a/src/Server/TaskHandler/NoOpTaskHandler.php
+++ b/src/Server/TaskHandler/NoOpTaskHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\TaskHandler;
+
+use Swoole\Server;
+
+final class NoOpTaskHandler implements TaskHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Server $server, int $taskId, int $fromId, $data): void
+    {
+        // noop
+    }
+}

--- a/src/Server/TaskHandler/TaskFinishedHandlerInterface.php
+++ b/src/Server/TaskHandler/TaskFinishedHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\TaskHandler;
+
+use Swoole\Server;
+
+/**
+ * Task Finished Handler is called only when Task Handler returns any result or Swoole\Server->finish() is called.
+ *
+ * @see https://www.swoole.co.uk/docs/modules/swoole-server/callback-functions#onfinish
+ */
+interface TaskFinishedHandlerInterface
+{
+    public function handle(Server $server, int $taskId, $data): void;
+}

--- a/src/Server/TaskHandler/TaskHandlerInterface.php
+++ b/src/Server/TaskHandler/TaskHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Server\TaskHandler;
+
+use Swoole\Server;
+
+interface TaskHandlerInterface
+{
+    public function handle(Server $server, int $taskId, int $fromId, $data): void;
+}

--- a/tests/Feature/SymfonyMessengerConsumeCommandTest.php
+++ b/tests/Feature/SymfonyMessengerConsumeCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Bridge\Symfony\Messenger\Exception\ReceiverNotAvailableException;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class SymfonyMessengerConsumeCommandTest extends ServerTestCase
+{
+    protected function setUp(): void
+    {
+        $this->markTestSkippedIfXdebugEnabled();
+    }
+
+    public function testConsumeMessagesFail(): void
+    {
+        $kernel = static::createKernel(['environment' => 'messenger']);
+        $application = new Application($kernel);
+
+        $command = $application->find('messenger:consume');
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(ReceiverNotAvailableException::class);
+        $this->expectExceptionMessage('Swoole Server Task transport does not implement Receiver interface methods. Messages sent via Swoole Server Task transport are dispatched inside task worker processes.');
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'receivers' => ['swoole'],
+        ]);
+    }
+}

--- a/tests/Feature/SymfonyMessengerSwooleTaskTransportTest.php
+++ b/tests/Feature/SymfonyMessengerSwooleTaskTransportTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Feature;
+
+use K911\Swoole\Client\HttpClient;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+use Swoole\Coroutine;
+
+final class SymfonyMessengerSwooleTaskTransportTest extends ServerTestCase
+{
+    protected function setUp(): void
+    {
+        $this->markTestSkippedIfXdebugEnabled();
+    }
+
+    public function testStartServerDispatchMessage(): void
+    {
+        $testFile = $this->generateNotExistingCustomTestFile();
+        $testFilePath = self::FIXTURE_RESOURCES_DIR.\DIRECTORY_SEPARATOR.$testFile;
+        $testFileContent = $this->generateUniqueHash(16);
+
+        $serverRun = $this->createConsoleProcess([
+            'swoole:server:run',
+            '--host=localhost',
+            '--port=9999',
+        ], ['APP_ENV' => 'messenger']);
+
+        $this->assertFileNotExists($testFilePath);
+
+        $serverRun->setTimeout(10);
+        $serverRun->start();
+
+        $this->goAndWait(function () use ($serverRun, $testFile, $testFileContent): void {
+            $this->deferProcessStop($serverRun);
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect());
+
+            $response = $client->send('/message/dispatch', 'POST', [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ], \http_build_query([
+                'fileName' => $testFile,
+                'content' => $testFileContent,
+            ]))['response'];
+
+            $this->assertSame(200, $response['statusCode']);
+            $this->assertSame('OK', $response['body']);
+
+            Coroutine::sleep($this->coverageEnabled() ? 1 : 3);
+        });
+
+        $this->assertFileExists($testFilePath);
+        $this->assertSame($testFileContent, \file_get_contents($testFilePath));
+    }
+
+    private function generateNotExistingCustomTestFile(): string
+    {
+        return 'tfile-'.$this->generateUniqueHash(4).'-'.$this->currentUnixTimestamp().'.txt';
+    }
+}

--- a/tests/Fixtures/Symfony/CoverageBundle/CoverageBundle.php
+++ b/tests/Fixtures/Symfony/CoverageBundle/CoverageBundle.php
@@ -9,6 +9,7 @@ use K911\Swoole\Server\LifecycleHandler\ServerManagerStopHandlerInterface;
 use K911\Swoole\Server\LifecycleHandler\ServerShutdownHandlerInterface;
 use K911\Swoole\Server\LifecycleHandler\ServerStartHandlerInterface;
 use K911\Swoole\Server\RequestHandler\RequestHandlerInterface;
+use K911\Swoole\Server\TaskHandler\TaskHandlerInterface;
 use K911\Swoole\Server\WorkerHandler\WorkerStartHandlerInterface;
 use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\Coverage\CodeCoverageManager;
 use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\EventListeners\CoverageFinishOnConsoleTerminate;
@@ -19,6 +20,7 @@ use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\ServerLifecycle\CoverageSt
 use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\ServerLifecycle\CoverageStartOnServerManagerStop;
 use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\ServerLifecycle\CoverageStartOnServerStart;
 use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\ServerLifecycle\CoverageStartOnServerWorkerStart;
+use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\TaskHandler\CodeCoverageTaskHandler;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\PHP;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -95,5 +97,11 @@ class CoverageBundle extends Bundle
             ->setAutoconfigured(true)
             ->setArgument('$decorated', new Reference(CoverageStartOnServerManagerStop::class.'.inner'))
             ->setDecoratedService(ServerManagerStopHandlerInterface::class);
+
+        $container->autowire(CodeCoverageTaskHandler::class)
+            ->setPublic(false)
+            ->setAutoconfigured(true)
+            ->setArgument('$decorated', new Reference(CodeCoverageTaskHandler::class.'.inner'))
+            ->setDecoratedService(TaskHandlerInterface::class);
     }
 }

--- a/tests/Fixtures/Symfony/CoverageBundle/TaskHandler/CodeCoverageTaskHandler.php
+++ b/tests/Fixtures/Symfony/CoverageBundle/TaskHandler/CodeCoverageTaskHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\TaskHandler;
+
+use K911\Swoole\Server\TaskHandler\TaskHandlerInterface;
+use K911\Swoole\Tests\Fixtures\Symfony\CoverageBundle\Coverage\CodeCoverageManager;
+use Swoole\Server;
+
+final class CodeCoverageTaskHandler implements TaskHandlerInterface
+{
+    private $decorated;
+    private $codeCoverageManager;
+
+    public function __construct(TaskHandlerInterface $decorated, CodeCoverageManager $codeCoverageManager)
+    {
+        $this->decorated = $decorated;
+        $this->codeCoverageManager = $codeCoverageManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Server $server, int $taskId, int $fromId, $data): void
+    {
+        $testName = \sprintf('test_task_%d_%d_%s', $taskId, $fromId, \bin2hex(\random_bytes(4)));
+        $this->codeCoverageManager->start($testName);
+
+        $this->decorated->handle($server, $taskId, $fromId, $data);
+
+        $this->codeCoverageManager->stop();
+        $this->codeCoverageManager->finish($testName);
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Controller/TaskController.php
+++ b/tests/Fixtures/Symfony/TestBundle/Controller/TaskController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Controller;
+
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Message\CreateFileMessage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class TaskController
+{
+    /**
+     * @Route(
+     *     methods={"GET","POST"},
+     *     path="/message/dispatch"
+     * )
+     *
+     * @param MessageBusInterface $bus
+     * @param Request             $request
+     *
+     * @throws \Exception
+     *
+     * @return Response
+     */
+    public function dispatchMessage(MessageBusInterface $bus, Request $request): Response
+    {
+        $fileName = $request->get('fileName', 'test-default-file.txt');
+        $content = $request->get('content', (new \DateTimeImmutable())->format(\DATE_ATOM));
+        $message = new CreateFileMessage($fileName, $content);
+        $bus->dispatch($message);
+
+        return new Response('OK', 200);
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Message/CreateFileMessage.php
+++ b/tests/Fixtures/Symfony/TestBundle/Message/CreateFileMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Message;
+
+final class CreateFileMessage
+{
+    private $fileName;
+    private $content;
+
+    public function __construct(string $fileName, string $content)
+    {
+        $this->fileName = $fileName;
+        $this->content = $content;
+    }
+
+    public function fileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function content(): string
+    {
+        return $this->content;
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/MessageHandler/CreateFileMessageHandler.php
+++ b/tests/Fixtures/Symfony/TestBundle/MessageHandler/CreateFileMessageHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Fixtures\Symfony\TestBundle\MessageHandler;
+
+use Assert\Assertion;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Message\CreateFileMessage;
+use K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class CreateFileMessageHandler
+{
+    public function __invoke(CreateFileMessage $message): void
+    {
+        $filePath = ServerTestCase::FIXTURE_RESOURCES_DIR.\DIRECTORY_SEPARATOR.\ltrim($message->fileName(), '\\/');
+        $result = \file_put_contents($filePath, $message->content());
+        Assertion::true(false !== $result, 'Could not create test file.');
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Test/ServerTestCase.php
+++ b/tests/Fixtures/Symfony/TestBundle/Test/ServerTestCase.php
@@ -183,4 +183,21 @@ class ServerTestCase extends KernelTestCase
         // Make sure everything is stopped
         \sleep(1);
     }
+
+    protected function generateUniqueHash(int $factor = 8): string
+    {
+        try {
+            return \bin2hex(\random_bytes($factor));
+        } catch (\Exception $e) {
+            $array = \range(1, $factor * 2);
+            \shuffle($array);
+
+            return \implode('', $array);
+        }
+    }
+
+    protected function currentUnixTimestamp(): int
+    {
+        return (new \DateTimeImmutable())->getTimestamp();
+    }
 }

--- a/tests/Fixtures/Symfony/TestBundle/TestBundle.php
+++ b/tests/Fixtures/Symfony/TestBundle/TestBundle.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace K911\Swoole\Tests\Fixtures\Symfony\TestBundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TestBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+    }
 }

--- a/tests/Fixtures/Symfony/app/config/messenger/messenger.yaml
+++ b/tests/Fixtures/Symfony/app/config/messenger/messenger.yaml
@@ -1,0 +1,82 @@
+framework:
+    messenger:
+        transports:
+            swoole: swoole://task
+        routing:
+            'K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Message\CreateFileMessage': swoole
+swoole:
+    http_server:
+        settings:
+            task_worker_count: auto
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    'K911\Swoole\Tests\Fixtures\Symfony\TestBundle\Controller\TaskController':
+        tags:
+            - controller.service_arguments
+
+    'K911\Swoole\Tests\Fixtures\Symfony\TestBundle\MessageHandler\CreateFileMessageHandler':
+        tags:
+            - messenger.message_handler
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/Unit/Server/Configurator/WithTaskFinishedHandlerTest.php
+++ b/tests/Unit/Server/Configurator/WithTaskFinishedHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Unit\Server\Configurator;
+
+use K911\Swoole\Server\Configurator\WithTaskFinishedHandler;
+use K911\Swoole\Server\HttpServerConfiguration;
+use K911\Swoole\Server\TaskHandler\NoOpTaskFinishedHandler;
+use K911\Swoole\Tests\Unit\Server\IntMother;
+use K911\Swoole\Tests\Unit\Server\SwooleHttpServerMock;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class WithTaskFinishedHandlerTest extends TestCase
+{
+    /**
+     * @var NoOpTaskFinishedHandler
+     */
+    private $noOpTaskFinishedHandler;
+
+    /**
+     * @var WithTaskFinishedHandler
+     */
+    private $configurator;
+
+    /**
+     * @var HttpServerConfiguration|ObjectProphecy
+     */
+    private $configurationProphecy;
+
+    protected function setUp(): void
+    {
+        $this->noOpTaskFinishedHandler = new NoOpTaskFinishedHandler();
+        $this->configurationProphecy = $this->prophesize(HttpServerConfiguration::class);
+
+        /** @var HttpServerConfiguration $configurationMock */
+        $configurationMock = $this->configurationProphecy->reveal();
+
+        $this->configurator = new WithTaskFinishedHandler($this->noOpTaskFinishedHandler, $configurationMock);
+    }
+
+    public function testConfigure(): void
+    {
+        $this->configurationProphecy->getTaskWorkerCount()
+            ->willReturn(IntMother::randomPositive())
+            ->shouldBeCalled();
+
+        $swooleServerOnEventSpy = SwooleHttpServerMock::make();
+
+        $this->configurator->configure($swooleServerOnEventSpy);
+
+        $this->assertTrue($swooleServerOnEventSpy->registeredEvent);
+        $this->assertSame(['finish', [$this->noOpTaskFinishedHandler, 'handle']], $swooleServerOnEventSpy->registeredEventPair);
+    }
+
+    public function testDoNotConfigureWhenNoTaskWorkers(): void
+    {
+        $this->configurationProphecy->getTaskWorkerCount()
+            ->willReturn(0)
+            ->shouldBeCalled();
+
+        $swooleServerOnEventSpy = SwooleHttpServerMock::make();
+
+        $this->configurator->configure($swooleServerOnEventSpy);
+
+        $this->assertFalse($swooleServerOnEventSpy->registeredEvent);
+    }
+}

--- a/tests/Unit/Server/Configurator/WithTaskHandlerTest.php
+++ b/tests/Unit/Server/Configurator/WithTaskHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Unit\Server\Configurator;
+
+use K911\Swoole\Server\Configurator\WithTaskHandler;
+use K911\Swoole\Server\HttpServerConfiguration;
+use K911\Swoole\Server\TaskHandler\NoOpTaskHandler;
+use K911\Swoole\Tests\Unit\Server\IntMother;
+use K911\Swoole\Tests\Unit\Server\SwooleHttpServerMock;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class WithTaskHandlerTest extends TestCase
+{
+    /**
+     * @var NoOpTaskHandler
+     */
+    private $noOpTaskHandler;
+
+    /**
+     * @var WithTaskHandler
+     */
+    private $configurator;
+
+    /**
+     * @var HttpServerConfiguration|ObjectProphecy
+     */
+    private $configurationProphecy;
+
+    protected function setUp(): void
+    {
+        $this->noOpTaskHandler = new NoOpTaskHandler();
+        $this->configurationProphecy = $this->prophesize(HttpServerConfiguration::class);
+
+        /** @var HttpServerConfiguration $configurationMock */
+        $configurationMock = $this->configurationProphecy->reveal();
+
+        $this->configurator = new WithTaskHandler($this->noOpTaskHandler, $configurationMock);
+    }
+
+    public function testConfigure(): void
+    {
+        $this->configurationProphecy->getTaskWorkerCount()
+            ->willReturn(IntMother::randomPositive())
+            ->shouldBeCalled();
+
+        $swooleServerOnEventSpy = SwooleHttpServerMock::make();
+
+        $this->configurator->configure($swooleServerOnEventSpy);
+
+        $this->assertTrue($swooleServerOnEventSpy->registeredEvent);
+        $this->assertSame(['task', [$this->noOpTaskHandler, 'handle']], $swooleServerOnEventSpy->registeredEventPair);
+    }
+
+    public function testDoNotConfigureWhenNoTaskWorkers(): void
+    {
+        $this->configurationProphecy->getTaskWorkerCount()
+            ->willReturn(0)
+            ->shouldBeCalled();
+
+        $swooleServerOnEventSpy = SwooleHttpServerMock::make();
+
+        $this->configurator->configure($swooleServerOnEventSpy);
+
+        $this->assertFalse($swooleServerOnEventSpy->registeredEvent);
+    }
+}

--- a/tests/Unit/Server/IntMother.php
+++ b/tests/Unit/Server/IntMother.php
@@ -6,12 +6,21 @@ namespace K911\Swoole\Tests\Unit\Server;
 
 use Exception;
 
-final class IdMother
+final class IntMother
 {
     public static function random(): int
     {
         try {
             return \random_int(0, 10000);
+        } catch (Exception $ex) {
+            return 0;
+        }
+    }
+
+    public static function randomPositive(): int
+    {
+        try {
+            return \random_int(1, 10000);
         } catch (Exception $ex) {
             return 0;
         }

--- a/tests/Unit/Server/WorkerHandler/HMRWorkerStartHandlerTest.php
+++ b/tests/Unit/Server/WorkerHandler/HMRWorkerStartHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace K911\Swoole\Tests\Unit\Server\WorkerHandler;
 
 use K911\Swoole\Server\WorkerHandler\HMRWorkerStartHandler;
-use K911\Swoole\Tests\Unit\Server\IdMother;
+use K911\Swoole\Tests\Unit\Server\IntMother;
 use K911\Swoole\Tests\Unit\Server\Runtime\HMR\HMRSpy;
 use K911\Swoole\Tests\Unit\Server\SwooleServerMock;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +36,7 @@ class HMRWorkerStartHandlerTest extends TestCase
     {
         $serverMock = SwooleServerMock::make(true);
 
-        $this->hmrWorkerStartHandler->handle($serverMock, IdMother::random());
+        $this->hmrWorkerStartHandler->handle($serverMock, IntMother::random());
 
         $this->assertFalse($serverMock->registeredTick);
     }
@@ -45,7 +45,7 @@ class HMRWorkerStartHandlerTest extends TestCase
     {
         $serverMock = SwooleServerMock::make();
 
-        $this->hmrWorkerStartHandler->handle($serverMock, IdMother::random());
+        $this->hmrWorkerStartHandler->handle($serverMock, IntMother::random());
 
         $this->assertTrue($serverMock->registeredTick);
         $this->assertSame(2000, $serverMock->registeredTickTuple[0]);


### PR DESCRIPTION
Asynchronously dispatch messages using Symfony Messanger API and Swoole inter-process communication (Swoole task) without serialization.

Notice: Symfony messenger `messenger:consume-messages` command is not supported. Dispatched messages are handled in task worker processes of Swoole server via `Swoole\Server->task()` interface, and thus cannot be dispatched in independent PHP process.

Usage:

1. Install `symfony/messenger` package via composer
2. Enable task workers inside configuration

    Example:

    ```yaml
    # config/packages/swoole.yaml
    swoole:
        http_server:
            ...
            settings:
                ...
                task_worker_count: auto
    ```
3. Configure swoole messenger transport

   Example:

   ```yaml
   # config/packages/messenger.yaml
   framework:
       messenger:
           transports:
               swoole: swoole://task
           routing:
               '*': swoole
   ```
4. (optional) Follow official [symfony messenger guide](https://symfony.com/doc/current/messenger.html) to define message object and its handler

Relates to #4