### PR TITLE
fix(server): Use \SplFile::getRealPath for Response::sendfile Operation for a BinaryFileReponse 

### DIFF
--- a/src/Bridge/Symfony/HttpFoundation/ResponseProcessor.php
+++ b/src/Bridge/Symfony/HttpFoundation/ResponseProcessor.php
@@ -44,7 +44,7 @@ final class ResponseProcessor implements ResponseProcessorInterface
         $swooleResponse->status($httpFoundationResponse->getStatusCode());
 
         if ($httpFoundationResponse instanceof BinaryFileResponse) {
-            $swooleResponse->sendfile($httpFoundationResponse->getFile()->getFilename());
+            $swooleResponse->sendfile($httpFoundationResponse->getFile()->getRealPath());
         } else {
             $swooleResponse->end($httpFoundationResponse->getContent());
         }


### PR DESCRIPTION
fix(server): Use \SplFile::getRealPath for Response::sendfile Operation for a BinaryFileReponse

Sorry for reopen... some misstake with the rebase
