### PR TITLE
Allow ext-swool 4.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
-        "ext-swoole": "~4.4.7",
+        "ext-swoole": "^4.4.7",
         "beberlei/assert": "^3.0",
         "symfony/config": "^4.3.1|^5.0",
         "symfony/console": "^4.3.1|^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53193581eedec217b66f6c9116a498d4",
+    "content-hash": "33d251a109767a4c7ae2c6dc3eab373a",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1673,6 +1673,12 @@
                 "Xdebug",
                 "performance"
             ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-03-01T12:26:26+00:00"
         },
         {
@@ -2710,6 +2716,12 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-15T18:51:10+00:00"
         },
         {
@@ -3494,6 +3506,20 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-19T20:35:10+00:00"
         },
         {
@@ -3781,6 +3807,12 @@
                 "filesystem",
                 "iterator"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-18T05:02:12+00:00"
         },
         {
@@ -4036,6 +4068,12 @@
             ],
             "description": "CLI frontend for php-code-coverage",
             "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-03-05T05:41:11+00:00"
         },
         {
@@ -4449,6 +4487,12 @@
                 "Xdebug",
                 "environment",
                 "hhvm"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
             "time": "2020-04-14T13:36:52+00:00"
         },
@@ -6641,7 +6685,7 @@
     "platform": {
         "php": "^7.3",
         "ext-json": "*",
-        "ext-swoole": "~4.4.7"
+        "ext-swoole": "^4.4.7"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Current swoole version is 4.5.0, which is not allowed by the current constraint.
This switches to carret `^` operator to allow `>=4.4.7 & <5.0.0`

Fixes #211 