### PR TITLE
feat(http_server): add max_request and max_request_grace configuration options

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -89,4 +89,11 @@ swoole:
 
             package_max_length: 8388608
             # in bytes, 8388608b = 8 MiB
+        
+            worker_max_request: 0
+            # integer >= 0, indicates the number of requests after which a worker reloads automatically
+            # This can be useful to limit memory leaks
+            worker_max_request_grace: ~
+            # 'grace period' for worker reloading. If not set, default is worker_max_request / 2. Worker reloads
+            # after 'worker_max_request + rand(0,worker_max_request_grace)' requests
 ```

--- a/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/AbstractServerStartCommand.php
@@ -202,6 +202,8 @@ abstract class AbstractServerStartCommand extends Command
             ['running_mode', $serverConfiguration->getRunningMode()],
             ['worker_count', $serverConfiguration->getWorkerCount()],
             ['reactor_count', $serverConfiguration->getReactorCount()],
+            ['worker_max_request', $serverConfiguration->getMaxRequest()],
+            ['worker_max_request_grace', $serverConfiguration->getMaxRequestGrace()],
             ['memory_limit', format_bytes(get_max_memory())],
             ['trusted_hosts', \implode(', ', $runtimeConfiguration['trustedHosts'])],
         ];

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -211,6 +211,13 @@ final class Configuration implements ConfigurationInterface
                                 ->scalarNode('task_worker_count')
                                     ->defaultNull()
                                 ->end()
+                                ->integerNode('worker_max_request')
+                                    ->min(0)
+                                    ->defaultValue(0)
+                                ->end()
+                                ->scalarNode('worker_max_request_grace')
+                                    ->defaultNull()
+                                ->end()
                             ->end()
                         ->end() // settings
                     ->end()


### PR DESCRIPTION
Hi @k911,

First of all, many thanks for the amazing bundle!
I needed to set the `max_request` and `max_request_grace` options from the bundle configuration so I thought of adding them.

I couldn't find any tests related to the configuration parsing and passing to Swoole, should I create one? If so, should I just test the HttpServerConfiguration class or should I also test parsing from Symfony's side?

Let me know, thanks!