### PR TITLE
refactor(error-handler): move to proper namespace

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -6,10 +6,10 @@ namespace K911\Swoole\Bridge\Symfony\Bundle\DependencyInjection;
 
 use Doctrine\ORM\EntityManagerInterface;
 use K911\Swoole\Bridge\Doctrine\ORM\EntityManagerHandler;
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\ErrorResponder;
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\ExceptionHandlerFactory;
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\SymfonyExceptionHandler;
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\ThrowableHandlerFactory;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\ErrorResponder;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\ExceptionHandlerFactory;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\SymfonyExceptionHandler;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\ThrowableHandlerFactory;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\CloudFrontRequestFactory;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactoryInterface;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\Session\SetSessionCookieEventListener;

--- a/src/Bridge/Symfony/ErrorHandler/ErrorResponder.php
+++ b/src/Bridge/Symfony/ErrorHandler/ErrorResponder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Bridge\Symfony\ErrorHandler;
 
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Bridge/Symfony/ErrorHandler/ExceptionHandlerFactory.php
+++ b/src/Bridge/Symfony/ErrorHandler/ExceptionHandlerFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Bridge\Symfony\ErrorHandler;
 
 use Error;
 use ErrorException;

--- a/src/Bridge/Symfony/ErrorHandler/SymfonyExceptionHandler.php
+++ b/src/Bridge/Symfony/ErrorHandler/SymfonyExceptionHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Bridge\Symfony\ErrorHandler;
 
 use K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactoryInterface;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface;

--- a/src/Bridge/Symfony/ErrorHandler/ThrowableHandlerFactory.php
+++ b/src/Bridge/Symfony/ErrorHandler/ThrowableHandlerFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Bridge\Symfony\ErrorHandler;
 
 use ReflectionClass;
 use ReflectionMethod;

--- a/src/Server/RequestHandler/AdvancedStaticFilesServer.php
+++ b/src/Server/RequestHandler/AdvancedStaticFilesServer.php
@@ -20,19 +20,23 @@ use Swoole\Http\Response;
  */
 final class AdvancedStaticFilesServer implements RequestHandlerInterface, BootableInterface
 {
+    private const MIME_TYPE_APPLICATION_OCTET_STREAM = 'application/octet-stream';
+
     /**
      * Default static file extensions supported.
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
      */
-    private $FILE_EXTENSION_MIME_TYPE_MAP = [
-        '*' => 'application/octet-stream', // fallback for other file types
+    private const FILE_EXTENSION_MIME_TYPE_DEFAULT_MAP = [
+        // fallback for other file types
+        '*' => self::MIME_TYPE_APPLICATION_OCTET_STREAM,
+        // default list
         '7z' => 'application/x-7z-compressed',
         'aac' => 'audio/aac',
-        'arc' => 'application/octet-stream',
+        'arc' => self::MIME_TYPE_APPLICATION_OCTET_STREAM,
         'avi' => 'video/x-msvideo',
         'azw' => 'application/vnd.amazon.ebook',
-        'bin' => 'application/octet-stream',
+        'bin' => self::MIME_TYPE_APPLICATION_OCTET_STREAM,
         'bmp' => 'image/bmp',
         'bz' => 'application/x-bzip',
         'bz2' => 'application/x-bzip2',
@@ -101,6 +105,11 @@ final class AdvancedStaticFilesServer implements RequestHandlerInterface, Bootab
      */
     private $publicDir;
 
+    /**
+     * @var array
+     */
+    private $fileExtensionMimeTypeMap;
+
     public function __construct(
         RequestHandlerInterface $decorated,
         HttpServerConfiguration $configuration,
@@ -108,7 +117,7 @@ final class AdvancedStaticFilesServer implements RequestHandlerInterface, Bootab
     ) {
         $this->decorated = $decorated;
         $this->configuration = $configuration;
-        $this->FILE_EXTENSION_MIME_TYPE_MAP = \array_merge($this->FILE_EXTENSION_MIME_TYPE_MAP, $customMimeTypes);
+        $this->fileExtensionMimeTypeMap = \array_merge(self::FILE_EXTENSION_MIME_TYPE_DEFAULT_MAP, $customMimeTypes);
         $this->cachedMimeTypes = [];
     }
 
@@ -157,11 +166,11 @@ final class AdvancedStaticFilesServer implements RequestHandlerInterface, Bootab
             return false;
         }
 
-        if (!isset($this->FILE_EXTENSION_MIME_TYPE_MAP[$extension])) {
+        if (!isset($this->fileExtensionMimeTypeMap[$extension])) {
             $extension = '*';
         }
 
-        $this->cachedMimeTypes[$path] = $this->FILE_EXTENSION_MIME_TYPE_MAP[$extension];
+        $this->cachedMimeTypes[$path] = $this->fileExtensionMimeTypeMap[$extension];
 
         return true;
     }

--- a/tests/Unit/Bridge/Symfony/ErrorHandler/ExceptionHandlerFactoryTest.php
+++ b/tests/Unit/Bridge/Symfony/ErrorHandler/ExceptionHandlerFactoryTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Tests\Unit\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Tests\Unit\Bridge\Symfony\ErrorHandler;
 
 use Error;
 use ErrorException;
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\ExceptionHandlerFactory;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\ExceptionHandlerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/tests/Unit/Bridge/Symfony/ErrorHandler/ThrowableHandlerFactoryTest.php
+++ b/tests/Unit/Bridge/Symfony/ErrorHandler/ThrowableHandlerFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace K911\Swoole\Tests\Unit\Bridge\Symfony\Bundle\ErrorHandler;
+namespace K911\Swoole\Tests\Unit\Bridge\Symfony\ErrorHandler;
 
-use K911\Swoole\Bridge\Symfony\Bundle\ErrorHandler\ThrowableHandlerFactory;
+use K911\Swoole\Bridge\Symfony\ErrorHandler\ThrowableHandlerFactory;
 use PHPUnit\Framework\TestCase;
 
 class ThrowableHandlerFactoryTest extends TestCase


### PR DESCRIPTION
- use const in AdvancedStaticFilesServer just as it was before