### PR TITLE
fix for #268 - fix(http): proper creation of $_SERVER['REQUEST_URI']

### DIFF
--- a/src/Bridge/Symfony/HttpFoundation/RequestFactory.php
+++ b/src/Bridge/Symfony/HttpFoundation/RequestFactory.php
@@ -21,6 +21,9 @@ final class RequestFactory implements RequestFactoryInterface
             $server['HTTP_'.\mb_strtoupper(\str_replace('-', '_', $key))] = $value;
         }
 
+        $queryString = $server['QUERY_STRING'] ?? '';
+        $server['REQUEST_URI'] = $server['REQUEST_URI'].('' !== $queryString ? '?'.$queryString : '');
+
         return new HttpFoundationRequest(
             $request->get ?? [],
             $request->post ?? [],


### PR DESCRIPTION
It's more complicated to call the request factory method and these two lines would need to be written anyway

Fixes #269 