### PR TITLE
Add support for StreamedResponse

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StreamedResponseListenerPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StreamedResponseListenerPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass;
+
+use K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseListener;
+use K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseProcessor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Replaces Symfony's native StreamedResponseListener with a custom one compatible with Swoole.
+ */
+final class StreamedResponseListenerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('streamed_response_listener')) {
+            $definition = $container->getDefinition('streamed_response_listener');
+            $definition
+                ->setClass(StreamedResponseListener::class)
+                ->setAutowired(true)
+            ;
+        } else {
+            $definition = $container
+                ->autowire('streamed_response_listener', StreamedResponseListener::class)
+                ->setAutoconfigured(true)
+            ;
+        }
+        $definition->setArgument(1, new Reference(StreamedResponseProcessor::class));
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
@@ -19,11 +19,32 @@ services:
 
     K911\Swoole\Bridge\Symfony\HttpFoundation\SetRequestRuntimeConfiguration:
 
+    K911\Swoole\Bridge\Symfony\HttpFoundation\SwooleRequestResponseContextManager:
+
     K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactoryInterface:
         class: K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactory
 
     K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface:
         class: K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessor
+
+    K911\Swoole\Bridge\Symfony\HttpFoundation\NoOpStreamedResponseProcessor:
+        decorates: K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface
+        arguments:
+            - '@K911\Swoole\Bridge\Symfony\HttpFoundation\NoOpStreamedResponseProcessor.inner'
+
+    response_processor.headers_and_cookies.default:
+        class: K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseHeadersAndStatusProcessor
+        decorates: K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface
+        arguments:
+            - '@response_processor.headers_and_cookies.default.inner'
+
+    K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseProcessor:
+
+    response_processor.headers_and_cookies.streamed:
+        class: K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseHeadersAndStatusProcessor
+        decorates: K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseProcessor
+        arguments:
+            - '@response_processor.headers_and_cookies.streamed.inner'
 
     K911\Swoole\Server\RequestHandler\RequestHandlerInterface:
         alias: K911\Swoole\Server\RequestHandler\ExceptionRequestHandler

--- a/src/Bridge/Symfony/Bundle/SwooleBundle.php
+++ b/src/Bridge/Symfony/Bundle/SwooleBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace K911\Swoole\Bridge\Symfony\Bundle;
 
 use K911\Swoole\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass\DebugLogProcessorPass;
+use K911\Swoole\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass\StreamedResponseListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -13,5 +14,6 @@ final class SwooleBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new DebugLogProcessorPass());
+        $container->addCompilerPass(new StreamedResponseListenerPass());
     }
 }

--- a/src/Bridge/Symfony/HttpFoundation/NoOpStreamedResponseProcessor.php
+++ b/src/Bridge/Symfony/HttpFoundation/NoOpStreamedResponseProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
+
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class NoOpStreamedResponseProcessor implements ResponseProcessorInterface
+{
+    /**
+     * @var ResponseProcessorInterface
+     */
+    private $decorated;
+
+    public function __construct(ResponseProcessorInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(HttpFoundationResponse $httpFoundationResponse, SwooleResponse $swooleResponse): void
+    {
+        if ($httpFoundationResponse instanceof StreamedResponse) {
+            return;
+        }
+
+        $this->decorated->process($httpFoundationResponse, $swooleResponse);
+    }
+}

--- a/src/Bridge/Symfony/HttpFoundation/ResponseHeadersAndStatusProcessor.php
+++ b/src/Bridge/Symfony/HttpFoundation/ResponseHeadersAndStatusProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
+
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+
+final class ResponseHeadersAndStatusProcessor implements ResponseProcessorInterface
+{
+    /**
+     * @var ResponseProcessorInterface
+     */
+    private $decorated;
+
+    public function __construct(ResponseProcessorInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(HttpFoundationResponse $httpFoundationResponse, SwooleResponse $swooleResponse): void
+    {
+        foreach ($httpFoundationResponse->headers->allPreserveCaseWithoutCookies() as $name => $values) {
+            $swooleResponse->header($name, \implode(', ', $values));
+        }
+
+        foreach ($httpFoundationResponse->headers->getCookies() as $cookie) {
+            $swooleResponse->cookie(
+                $cookie->getName(),
+                $cookie->getValue() ?? '',
+                $cookie->getExpiresTime(),
+                $cookie->getPath(),
+                $cookie->getDomain() ?? '',
+                $cookie->isSecure(),
+                $cookie->isHttpOnly(),
+                $cookie->getSameSite() ?? ''
+            );
+        }
+
+        $swooleResponse->status($httpFoundationResponse->getStatusCode());
+
+        $this->decorated->process($httpFoundationResponse, $swooleResponse);
+    }
+}

--- a/src/Bridge/Symfony/HttpFoundation/ResponseProcessor.php
+++ b/src/Bridge/Symfony/HttpFoundation/ResponseProcessor.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
 
-use RuntimeException;
 use Swoole\Http\Response as SwooleResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final class ResponseProcessor implements ResponseProcessorInterface
 {
@@ -17,29 +15,6 @@ final class ResponseProcessor implements ResponseProcessorInterface
      */
     public function process(HttpFoundationResponse $httpFoundationResponse, SwooleResponse $swooleResponse): void
     {
-        if ($httpFoundationResponse instanceof StreamedResponse) {
-            throw new RuntimeException('HttpFoundation "StreamedResponse" response object is not yet supported');
-        }
-
-        foreach ($httpFoundationResponse->headers->allPreserveCaseWithoutCookies() as $name => $values) {
-            $swooleResponse->header($name, \implode(', ', $values));
-        }
-
-        foreach ($httpFoundationResponse->headers->getCookies() as $cookie) {
-            $swooleResponse->cookie(
-                $cookie->getName(),
-                $cookie->getValue() ?? '',
-                $cookie->getExpiresTime(),
-                $cookie->getPath(),
-                $cookie->getDomain() ?? '',
-                $cookie->isSecure(),
-                $cookie->isHttpOnly(),
-                $cookie->getSameSite() ?? ''
-            );
-        }
-
-        $swooleResponse->status($httpFoundationResponse->getStatusCode());
-
         if ($httpFoundationResponse instanceof BinaryFileResponse) {
             $swooleResponse->sendfile($httpFoundationResponse->getFile()->getRealPath());
         } else {

--- a/src/Bridge/Symfony/HttpFoundation/StreamedResponseListener.php
+++ b/src/Bridge/Symfony/HttpFoundation/StreamedResponseListener.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class StreamedResponseListener implements EventSubscriberInterface
+{
+    private $contextManager;
+    private $responseProcessor;
+
+    public function __construct(
+        SwooleRequestResponseContextManager $contextManager,
+        ResponseProcessorInterface $responseProcessor
+    ) {
+        $this->responseProcessor = $responseProcessor;
+        $this->contextManager = $contextManager;
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        if ($response instanceof StreamedResponse) {
+            $swooleResponse = $this->contextManager->findResponse($event->getRequest());
+            $this->responseProcessor->process($response, $swooleResponse);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', -1024],
+        ];
+    }
+}

--- a/src/Bridge/Symfony/HttpFoundation/StreamedResponseProcessor.php
+++ b/src/Bridge/Symfony/HttpFoundation/StreamedResponseProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
+
+use Assert\Assertion;
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class StreamedResponseProcessor implements ResponseProcessorInterface
+{
+    private $bufferOutputSize;
+
+    public function __construct(int $bufferOutputSize = 8192)
+    {
+        $this->bufferOutputSize = $bufferOutputSize;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(HttpFoundationResponse $httpFoundationResponse, SwooleResponse $swooleResponse): void
+    {
+        Assertion::isInstanceOf($httpFoundationResponse, StreamedResponse::class);
+
+        \ob_start(static function (string $payload) use ($swooleResponse) {
+            if ('' !== $payload) {
+                $swooleResponse->write($payload);
+            }
+
+            return '';
+        }, $this->bufferOutputSize);
+        $httpFoundationResponse->sendContent();
+        \ob_end_clean();
+        $swooleResponse->end();
+    }
+}

--- a/src/Bridge/Symfony/HttpFoundation/SwooleRequestResponseContextManager.php
+++ b/src/Bridge/Symfony/HttpFoundation/SwooleRequestResponseContextManager.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Bridge\Symfony\HttpFoundation;
+
+use Swoole\Http\Request as SwooleRequest;
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Request as HttpFoundationRequest;
+
+final class SwooleRequestResponseContextManager
+{
+    private const REQUEST_ATTR_KEY = 'swoole_request';
+    private const RESPONSE_ATTR_KEY = 'swoole_response';
+
+    public function attachRequestResponseAttributes(
+        HttpFoundationRequest $request,
+        SwooleRequest $swooleRequest,
+        SwooleResponse $swooleResponse
+    ): void {
+        $request->attributes->set(static::REQUEST_ATTR_KEY, $swooleRequest);
+        $request->attributes->set(static::RESPONSE_ATTR_KEY, $swooleResponse);
+    }
+
+    public function findRequest(
+        HttpFoundationRequest $request
+    ): SwooleRequest {
+        return $request->attributes->get(static::REQUEST_ATTR_KEY);
+    }
+
+    public function findResponse(
+        HttpFoundationRequest $request
+    ): SwooleResponse {
+        return $request->attributes->get(static::RESPONSE_ATTR_KEY);
+    }
+}

--- a/src/Bridge/Symfony/HttpKernel/HttpKernelRequestHandler.php
+++ b/src/Bridge/Symfony/HttpKernel/HttpKernelRequestHandler.php
@@ -6,6 +6,7 @@ namespace K911\Swoole\Bridge\Symfony\HttpKernel;
 
 use K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactoryInterface;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface;
+use K911\Swoole\Bridge\Symfony\HttpFoundation\SwooleRequestResponseContextManager;
 use K911\Swoole\Server\RequestHandler\RequestHandlerInterface;
 use K911\Swoole\Server\Runtime\BootableInterface;
 use Swoole\Http\Request as SwooleRequest;
@@ -15,15 +16,21 @@ use Symfony\Component\HttpKernel\TerminableInterface;
 
 final class HttpKernelRequestHandler implements RequestHandlerInterface, BootableInterface
 {
+    private $contextManager;
     private $kernel;
     private $requestFactory;
     private $responseProcessor;
 
-    public function __construct(KernelInterface $kernel, RequestFactoryInterface $requestFactory, ResponseProcessorInterface $responseProcessor)
-    {
+    public function __construct(
+        KernelInterface $kernel,
+        RequestFactoryInterface $requestFactory,
+        SwooleRequestResponseContextManager $contextManager,
+        ResponseProcessorInterface $responseProcessor
+    ) {
         $this->kernel = $kernel;
         $this->requestFactory = $requestFactory;
         $this->responseProcessor = $responseProcessor;
+        $this->contextManager = $contextManager;
     }
 
     /**
@@ -42,6 +49,7 @@ final class HttpKernelRequestHandler implements RequestHandlerInterface, Bootabl
     public function handle(SwooleRequest $request, SwooleResponse $response): void
     {
         $httpFoundationRequest = $this->requestFactory->make($request);
+        $this->contextManager->attachRequestResponseAttributes($httpFoundationRequest, $request, $response);
         $httpFoundationResponse = $this->kernel->handle($httpFoundationRequest);
         $this->responseProcessor->process($httpFoundationResponse, $response);
 

--- a/tests/Unit/Bridge/Symfony/HttpFoundation/ResponseHeadersAndStatusProcessorTest.php
+++ b/tests/Unit/Bridge/Symfony/HttpFoundation/ResponseHeadersAndStatusProcessorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Unit\Bridge\Symfony\HttpFoundation;
+
+use K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseHeadersAndStatusProcessor;
+use K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+
+class ResponseHeadersAndStatusProcessorTest extends TestCase
+{
+    use \Prophecy\PhpUnit\ProphecyTrait;
+    /**
+     * @var null|ObjectProphecy|ResponseHeadersAndStatusProcessor
+     */
+    protected $responseProcessor;
+
+    /**
+     * @var null|ObjectProphecy|SwooleResponse
+     */
+    protected $swooleResponse;
+
+    protected function setUp(): void
+    {
+        $this->swooleResponse = $this->prophesize(SwooleResponse::class);
+        $decoratedProcessor = $this->prophesize(ResponseProcessorInterface::class);
+        $decoratedProcessor
+            ->process(Argument::type(HttpFoundationResponse::class), $this->swooleResponse->reveal())
+            ->shouldBeCalled()
+        ;
+        $this->responseProcessor = new ResponseHeadersAndStatusProcessor($decoratedProcessor->reveal());
+    }
+
+    public function testProcess(): void
+    {
+        $symfonyResponse = new HttpFoundationResponse(
+            'success',
+            200,
+            [
+                'Vary' => [
+                    'Content-Type',
+                    'Authorization',
+                    'Origin',
+                ],
+            ]
+        );
+
+        $swooleResponse = $this->swooleResponse->reveal();
+        $this->swooleResponse->status(200)->shouldBeCalled();
+        foreach ($symfonyResponse->headers->allPreserveCaseWithoutCookies() as $name => $values) {
+            $this->swooleResponse->header($name, \implode(', ', $values))->shouldBeCalled();
+        }
+        $this->responseProcessor->process($symfonyResponse, $swooleResponse);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/HttpFoundation/ResponseProcessorTest.php
+++ b/tests/Unit/Bridge/Symfony/HttpFoundation/ResponseProcessorTest.php
@@ -36,8 +36,9 @@ class ResponseProcessorTest extends TestCase
 
     public function testProcess(): void
     {
+        $content = 'success';
         $this->symfonyResponse = new HttpFoundationResponse(
-            'success',
+            $content,
             200,
             [
                 'Vary' => [
@@ -49,7 +50,7 @@ class ResponseProcessorTest extends TestCase
         );
 
         $swooleResponse = $this->swooleResponse->reveal();
+        $this->swooleResponse->end($content)->shouldBeCalled();
         $this->responseProcessor->process($this->symfonyResponse, $swooleResponse);
-        $this->swooleResponse->header('Vary', 'Content-Type, Authorization, Origin')->shouldBeCalled();
     }
 }

--- a/tests/Unit/Bridge/Symfony/HttpFoundation/StreamedResponseProcessorTest.php
+++ b/tests/Unit/Bridge/Symfony/HttpFoundation/StreamedResponseProcessorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Unit\Bridge\Symfony\HttpFoundation;
+
+use K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseProcessor;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Swoole\Http\Response as SwooleResponse;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class StreamedResponseProcessorTest extends TestCase
+{
+    use \Prophecy\PhpUnit\ProphecyTrait;
+    /**
+     * @var StreamedResponseProcessor
+     */
+    protected $responseProcessor;
+
+    /**
+     * @var null|HttpFoundationResponse
+     */
+    protected $symfonyResponse;
+
+    /**
+     * @var null|ObjectProphecy|SwooleResponse
+     */
+    protected $swooleResponse;
+
+    /**
+     * @var int
+     */
+    private $bufferSize;
+
+    protected function setUp(): void
+    {
+        $this->bufferSize = 10;
+        $this->responseProcessor = new StreamedResponseProcessor($this->bufferSize);
+        $this->swooleResponse = $this->prophesize(SwooleResponse::class);
+    }
+
+    public function testProcess(): void
+    {
+        $expectedContentLength = $this->bufferSize * 3;
+        $this->symfonyResponse = new StreamedResponse(
+            static function () use ($expectedContentLength): void {
+                for ($i = 0; $i < $expectedContentLength; ++$i) {
+                    echo 'A';
+                }
+            },
+            200,
+        );
+
+        $remainingContentLength = $expectedContentLength;
+        while ($remainingContentLength > 0) {
+            $bufferedContentLength = \min($this->bufferSize, $remainingContentLength);
+            $this->swooleResponse->write(\str_repeat('A', $bufferedContentLength))->shouldBeCalled();
+            $remainingContentLength -= $bufferedContentLength;
+        }
+        $this->swooleResponse->end()->shouldBeCalled();
+        $swooleResponse = $this->swooleResponse->reveal();
+        $this->responseProcessor->process($this->symfonyResponse, $swooleResponse);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/HttpKernel/HttpKernelHttpDriverTest.php
+++ b/tests/Unit/Bridge/Symfony/HttpKernel/HttpKernelHttpDriverTest.php
@@ -6,6 +6,7 @@ namespace K911\Swoole\Tests\Unit\Bridge\Symfony\HttpKernel;
 
 use K911\Swoole\Bridge\Symfony\HttpFoundation\RequestFactoryInterface;
 use K911\Swoole\Bridge\Symfony\HttpFoundation\ResponseProcessorInterface;
+use K911\Swoole\Bridge\Symfony\HttpFoundation\SwooleRequestResponseContextManager;
 use K911\Swoole\Bridge\Symfony\HttpKernel\HttpKernelRequestHandler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -52,7 +53,12 @@ class HttpKernelHttpDriverTest extends TestCase
         /** @var ResponseProcessorInterface $responseProcessorMock */
         $responseProcessorMock = $this->responseProcessor->reveal();
 
-        $this->httpDriver = new HttpKernelRequestHandler($kernelMock, $requestFactoryMock, $responseProcessorMock);
+        $this->httpDriver = new HttpKernelRequestHandler(
+            $kernelMock,
+            $requestFactoryMock,
+            new SwooleRequestResponseContextManager(),
+            $responseProcessorMock
+        );
     }
 
     public function testBoot(): void
@@ -112,6 +118,11 @@ class HttpKernelHttpDriverTest extends TestCase
         /** @var ResponseProcessorInterface $responseProcessorMock */
         $responseProcessorMock = $this->responseProcessor->reveal();
 
-        $this->httpDriver = new HttpKernelRequestHandler($kernelMock, $requestFactoryMock, $responseProcessorMock);
+        $this->httpDriver = new HttpKernelRequestHandler(
+            $kernelMock,
+            $requestFactoryMock,
+            new SwooleRequestResponseContextManager(),
+            $responseProcessorMock
+        );
     }
 }


### PR DESCRIPTION
This PR adds support for StreamedResponse by making use of PHP's output buffering functions.

It's designed to behave as close as possible to original StreamedResponse handling when running Symfony with php-fpm. Compiler pass replaces Symfony's Symfony\Component\HttpKernel\EventListener\StreamedResponseListener with a custom listener, which triggers returning response to the client. The reason listener is used instead of simply calling the response processor from the HttpKernelRequestHandler is the same as originally in Symfony - a callback in StreamedResponse may depend on some services, which depend on Request context (current Request being present in RequestStack). Also error handling that you have in your Symfony app can kick in if the callback fails, which is not the case if we process the StreamedResponse outside of the request context.

Before I start writing tests, please let me know first if the overall design of this solution looks good to you, or you'd rather take some different approach.
