### PR TITLE
Fixed resetting SwooleSessionStorage when Symfony HTTP Cache is used

### DIFF
--- a/src/Bridge/Symfony/HttpFoundation/Session/SetSessionCookieEventListener.php
+++ b/src/Bridge/Symfony/HttpFoundation/Session/SetSessionCookieEventListener.php
@@ -9,10 +9,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -66,9 +66,9 @@ final class SetSessionCookieEventListener implements EventSubscriberInterface
         $responseHeaderBag->setCookie($this->makeSessionCookie($session));
     }
 
-    public function onKernelTerminate(TerminateEvent $event): void
+    public function onFinishRequest(FinishRequestEvent $event): void
     {
-        if (!$this->isSessionRelated($event)) {
+        if (!$event->isMasterRequest() || !$this->isSessionRelated($event)) {
             return;
         }
 
@@ -84,7 +84,7 @@ final class SetSessionCookieEventListener implements EventSubscriberInterface
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 192],
             KernelEvents::RESPONSE => ['onKernelResponse', -128],
-            KernelEvents::TERMINATE => ['onKernelTerminate', -128],
+            KernelEvents::FINISH_REQUEST => ['onFinishRequest', -128],
         ];
     }
 

--- a/tests/Fixtures/Symfony/TestCacheKernel.php
+++ b/tests/Fixtures/Symfony/TestCacheKernel.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K911\Swoole\Tests\Fixtures\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
+
+class TestCacheKernel extends HttpCache
+{
+}


### PR DESCRIPTION
It's a good idea to reset the state regardless of the request being session related or not. There can be different reasons why session storage may get populated, while request may not contain a session.
One of the real world cases that I encountered - use of CacheKernel:
1. CacheKernel gets the original request, which will not be considered as "sessionRelated", because session isn't initialized in there, even if request technically contains session info.
2. If there's no cache entry, Request object is *cloned* and passed to the normal Kernel. Somewhere within that kernel session is initiated and set to SwooleSessionStorage and to Request. Request object is "sessionRelated" now.
3. Request is handled, response is sent.
4. Kernel termination is initiated. But we're out of context of the cloned "sessionRelated" request. All we have is the original Request object with no Session in it.
Result - session storage is not reset. Next request fails, because it tries to initiate a session again with a not cleared SwooleSessionStorage.