### PR TITLE
Avoid accessing undefined index REQUEST_URI

### DIFF
--- a/src/Bridge/Symfony/HttpFoundation/RequestFactory.php
+++ b/src/Bridge/Symfony/HttpFoundation/RequestFactory.php
@@ -22,7 +22,8 @@ final class RequestFactory implements RequestFactoryInterface
         }
 
         $queryString = $server['QUERY_STRING'] ?? '';
-        $server['REQUEST_URI'] = $server['REQUEST_URI'].('' !== $queryString ? '?'.$queryString : '');
+        $server['REQUEST_URI'] = $server['REQUEST_URI'] ?? '';
+        $server['REQUEST_URI'] .= '' !== $queryString ? '?'.$queryString : '';
 
         return new HttpFoundationRequest(
             $request->get ?? [],


### PR DESCRIPTION
REQUEST_URI could be missing for some invalid/malformed requests (we see it occasionally in production).
When it's missing, accessing undefined array index triggers PHP notice.

This PR ensures that REQUEST_URI defaults to an empty string if not set.