### PR TITLE
Fix ApiServerClient factory

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.yaml
@@ -102,7 +102,7 @@ services:
     K911\Swoole\Server\Api\ApiServerClientFactory:
 
     K911\Swoole\Server\Api\ApiServerClient:
-        factory: K911\Swoole\Server\Api\ApiServerClientFactory:newClient
+        factory: K911\Swoole\Server\Api\ApiServerClientFactory::newClient
 
     K911\Swoole\Server\Api\ApiServerInterface:
         class: K911\Swoole\Server\Api\ApiServer


### PR DESCRIPTION
In Symfony 5.4 factory format is wrong. Should be "::" not ":"

```
    K911\Swoole\Server\Api\ApiServerClient:
        factory: K911\Swoole\Server\Api\ApiServerClientFactory:newClient
```

```
    K911\Swoole\Server\Api\ApiServerClient:
        factory: K911\Swoole\Server\Api\ApiServerClientFactory::newClient
```