### PR TITLE
Require openswoole instead of swoole

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "ext-swoole": "^4.5.10",
+        "ext-openswoole": "^4.7.1",
         "beberlei/assert": "^3.0",
         "symfony/config": "^4.4.0|^5.0",
         "symfony/console": "^4.4.0|^5.0",


### PR DESCRIPTION
A fork of swoole named openswoole have been created due to security concerns: https://news-web.php.net/php.pecl.dev/17446

This PR only switch the composer deps from swoole to openswoole.